### PR TITLE
Fixed visibility for Swift 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ DerivedData/
 !default.perspectivev3
 xcuserdata/
 
+## AppCode
+.idea
+.idea/
+
 ## Other
 *.moved-aside
 *.xccheckout

--- a/Sources/Collections/CollectionSkeletonProtocol.swift
+++ b/Sources/Collections/CollectionSkeletonProtocol.swift
@@ -9,13 +9,13 @@
 import UIKit
 
 extension UIView {
-    
+
     func addDummyDataSourceIfNeeded() {
         guard let collection = self as? CollectionSkeleton else { return }
         collection.addDummyDataSource()
         collection.disableScrolling()
     }
-    
+
     func removeDummyDataSourceIfNeeded(reloadAfter reload: Bool = true) {
         guard let collection = self as? CollectionSkeleton else { return }
         collection.removeDummyDataSource(reloadAfter: reload)
@@ -36,7 +36,6 @@ private enum AssociatedKeys {
 }
 
 extension CollectionSkeleton where Self: UIScrollView {
-    
     func addDummyDataSource() {}
     func removeDummyDataSource(reloadAfter: Bool) {}
     func disableScrolling() { isScrollEnabled = false }
@@ -44,16 +43,18 @@ extension CollectionSkeleton where Self: UIScrollView {
 }
 
 extension UITableView: CollectionSkeleton {
-    
-    var skeletonDataSource: SkeletonCollectionDataSource? {
-        get { return objc_getAssociatedObject(self, &AssociatedKeys.dummyDataSource) as? SkeletonCollectionDataSource }
+
+    public var skeletonDataSource: SkeletonCollectionDataSource? {
+        get {
+            return objc_getAssociatedObject(self, &AssociatedKeys.dummyDataSource) as? SkeletonCollectionDataSource
+        }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.dummyDataSource, newValue, AssociationPolicy.retain.objc)
             self.dataSource = newValue
         }
     }
-    
-    func addDummyDataSource() {
+
+    func addDummyDataSource() { // todo rename to "activateSkeletonDataSource"
         guard let originalDataSource = self.dataSource as? SkeletonTableViewDataSource,
               !(originalDataSource is SkeletonCollectionDataSource)
             else { return }
@@ -61,8 +62,8 @@ extension UITableView: CollectionSkeleton {
         self.skeletonDataSource = dataSource
         reloadData()
     }
-    
-    func removeDummyDataSource(reloadAfter: Bool) {
+
+    func removeDummyDataSource(reloadAfter: Bool) { // todo rename to "deactivateSkeletonDataSource"
         guard let dataSource = self.dataSource as? SkeletonCollectionDataSource else { return }
         self.skeletonDataSource = nil
         self.dataSource = dataSource.originalTableViewDataSource
@@ -71,8 +72,8 @@ extension UITableView: CollectionSkeleton {
 }
 
 extension UICollectionView: CollectionSkeleton {
-    
-    var skeletonDataSource: SkeletonCollectionDataSource? {
+
+    public var skeletonDataSource: SkeletonCollectionDataSource? {
         get { return objc_getAssociatedObject(self, &AssociatedKeys.dummyDataSource) as? SkeletonCollectionDataSource }
         set { objc_setAssociatedObject(self, &AssociatedKeys.dummyDataSource, newValue, AssociationPolicy.retain.objc) }
     }

--- a/Sources/Collections/SkeletonCollectionDataSource.swift
+++ b/Sources/Collections/SkeletonCollectionDataSource.swift
@@ -10,12 +10,12 @@ import UIKit
 
 public typealias ReusableCellIdentifier = String
 
-class SkeletonCollectionDataSource: NSObject {
-    
+public class SkeletonCollectionDataSource: NSObject {
+
     weak var originalTableViewDataSource: SkeletonTableViewDataSource?
     weak var originalCollectionViewDataSource: UICollectionViewDataSource?
-    
-    convenience init(tableViewDataSource: SkeletonTableViewDataSource? = nil, collectionViewDataSource: UICollectionViewDataSource? = nil) {
+
+    public convenience init(tableViewDataSource: SkeletonTableViewDataSource? = nil, collectionViewDataSource: UICollectionViewDataSource? = nil) {
         self.init()
         self.originalTableViewDataSource = tableViewDataSource
         self.originalCollectionViewDataSource = collectionViewDataSource
@@ -24,17 +24,17 @@ class SkeletonCollectionDataSource: NSObject {
 
 // MARK: - UITableViewDataSource
 extension SkeletonCollectionDataSource: UITableViewDataSource {
-    
-    func numberOfSections(in tableView: UITableView) -> Int {
-        return originalTableViewDataSource?.numSections(in:tableView) ?? 0
+
+    public func numberOfSections(in tableView: UITableView) -> Int {
+        return originalTableViewDataSource?.numSections(in: tableView) ?? 0
     }
-    
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return originalTableViewDataSource?.collectionSkeletonView(tableView, numberOfRowsInSection:section) ?? 0
+
+    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return originalTableViewDataSource?.collectionSkeletonView(tableView, numberOfRowsInSection: section) ?? 0
     }
-    
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cellIdentifier = originalTableViewDataSource?.collectionSkeletonView(tableView, cellIdenfierForRowAt: indexPath) ?? ""
+
+    public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cellIdentifier = originalTableViewDataSource?.collectionSkeletonView(tableView, cellIdentifierForRowAt: indexPath) ?? ""
         let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
         return cell
     }
@@ -42,16 +42,16 @@ extension SkeletonCollectionDataSource: UITableViewDataSource {
 
 // MARK: - UICollectionViewDataSource
 extension SkeletonCollectionDataSource: UICollectionViewDataSource {
-    
-    func numberOfSections(in collectionView: UICollectionView) -> Int {
+
+    public func numberOfSections(in collectionView: UICollectionView) -> Int {
         return 1
     }
-    
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+
+    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return 4
     }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+
+    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         return UICollectionViewCell()
     }
 }

--- a/Sources/Collections/SkeletonUITableViewDataSource.swift
+++ b/Sources/Collections/SkeletonUITableViewDataSource.swift
@@ -11,14 +11,14 @@ import UIKit
 public protocol SkeletonTableViewDataSource: UITableViewDataSource {
     func numSections(in collectionSkeletonView: UITableView) -> Int
     func collectionSkeletonView(_ skeletonView: UITableView, numberOfRowsInSection section: Int) -> Int
-    func collectionSkeletonView(_ skeletonView: UITableView, cellIdenfierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier
+    func collectionSkeletonView(_ skeletonView: UITableView, cellIdentifierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier
 }
 
 public extension SkeletonTableViewDataSource {
-    
+
     func collectionSkeletonView(_ skeletonView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return Int(ceil(skeletonView.frame.height/skeletonView.rowHeight))
     }
-    
+
     func numSections(in collectionSkeletonView: UITableView) -> Int { return 1 }
 }

--- a/Sources/Extensions/CALayer+Extensions.swift
+++ b/Sources/Extensions/CALayer+Extensions.swift
@@ -26,33 +26,33 @@ extension CAGradientLayer {
     }
 }
 
-
 // MARK: Skeleton sublayers
 extension CALayer {
-    
+
     static let skeletonSubLayersName = "SkeletonSubLayersName"
 
     var skeletonSublayers: [CALayer] {
         return sublayers?.filter { $0.name == CALayer.skeletonSubLayersName } ?? [CALayer]()
     }
-    
+
     func addMultilinesLayers(lines: Int, type: SkeletonType) {
         let numberOfSublayers = calculateNumLines(maxLines: lines)
         for index in 0..<numberOfSublayers {
-            let layer = SkeletonLayerFactory().makeMultilineLayer(withType: type, for: index, width: Int(bounds.width))
+            let layer = SkeletonLayerFactory.makeMultilineLayer(withType: type, for: index, width: Int(bounds.width))
             addSublayer(layer)
         }
     }
-    
+
     private func calculateNumLines(maxLines: Int) -> Int {
         let spaceRequitedForEachLine = SkeletonDefaultConfig.multilineHeight + SkeletonDefaultConfig.multilineSpacing
         var numberOfSublayers = Int(round(CGFloat(bounds.height)/CGFloat(spaceRequitedForEachLine)))
-        if maxLines != 0,  maxLines <= numberOfSublayers { numberOfSublayers = maxLines }
+        if maxLines != 0, maxLines <= numberOfSublayers { numberOfSublayers = maxLines }
         return numberOfSublayers
     }
 }
 
 // MARK: Animations
+
 public extension CALayer {
 
     var pulse: CAAnimation {
@@ -65,32 +65,32 @@ public extension CALayer {
         pulseAnimation.repeatCount = .infinity
         return pulseAnimation
     }
-    
+
     var sliding: CAAnimation {
         let startPointAnim = CABasicAnimation(keyPath: #keyPath(CAGradientLayer.startPoint))
-        startPointAnim.fromValue = NSValue(cgPoint:CGPoint(x: -1, y: 0.5))
-        startPointAnim.toValue = NSValue(cgPoint:CGPoint(x:1, y: 0.5))
-        
+        startPointAnim.fromValue = NSValue(cgPoint: CGPoint(x: -1, y: 0.5))
+        startPointAnim.toValue = NSValue(cgPoint: CGPoint(x: 1, y: 0.5))
+
         let endPointAnim = CABasicAnimation(keyPath: #keyPath(CAGradientLayer.endPoint))
-        endPointAnim.fromValue = NSValue(cgPoint:CGPoint(x: 0, y: 0.5))
-        endPointAnim.toValue = NSValue(cgPoint:CGPoint(x:2, y: 0.5))
-        
+        endPointAnim.fromValue = NSValue(cgPoint: CGPoint(x: 0, y: 0.5))
+        endPointAnim.toValue = NSValue(cgPoint: CGPoint(x: 2, y: 0.5))
+
         let animGroup = CAAnimationGroup()
         animGroup.animations = [startPointAnim, endPointAnim]
         animGroup.duration = 1.5
         animGroup.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseIn)
         animGroup.repeatCount = .infinity
-        
+
         return animGroup
     }
-    
+
     func playAnimation(_ anim: SkeletonLayerAnimation, key: String) {
         recursiveSearch(inArray: skeletonSublayers,
                         leafBlock: { add(anim(self), forKey: key) }) {
                             $0.playAnimation(anim, key: key)
         }
     }
-    
+
     func stopAnimation(forKey key: String) {
         recursiveSearch(inArray: skeletonSublayers,
                         leafBlock: { removeAnimation(forKey: key) }) {

--- a/Sources/Extensions/UIColor+Skeleton.swift
+++ b/Sources/Extensions/UIColor+Skeleton.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 extension UIColor {
-    
+
     convenience init(_ hex: UInt) {
         self.init(
             red: CGFloat((hex & 0xFF0000) >> 16) / 255.0,
@@ -18,7 +18,7 @@ extension UIColor {
             alpha: CGFloat(1.0)
         )
     }
-    
+
     func isLight() -> Bool {
         // algorithm from: http://www.w3.org/WAI/ER/WD-AERT/#color-contrast
         guard let components = cgColor.components,
@@ -26,25 +26,25 @@ extension UIColor {
         let brightness = ((components[0] * 299) + (components[1] * 587) + (components[2] * 114)) / 1000
         return !(brightness < 0.5)
     }
-    
+
     public var complementaryColor: UIColor {
         return isLight() ? darker : lighter
     }
-    
+
     public var lighter: UIColor {
         return adjust(by: 1.35)
     }
-    
+
     public var darker: UIColor {
         return adjust(by: 0.94)
     }
-    
+
     func adjust(by percent: CGFloat) -> UIColor {
         var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
         getHue(&h, saturation: &s, brightness: &b, alpha: &a)
         return UIColor(hue: h, saturation: s, brightness: b * percent, alpha: a)
     }
-    
+
     func makeGradient() -> [UIColor] {
         return [self, self.complementaryColor, self]
     }
@@ -72,4 +72,3 @@ public extension UIColor {
     static var silver       = UIColor(0xbdc3c7)
     static var asbestos     = UIColor(0x7f8c8d)
 }
-

--- a/Sources/Extensions/UIView+Frame.swift
+++ b/Sources/Extensions/UIView+Frame.swift
@@ -10,26 +10,26 @@ import UIKit
 
 // MARK: Frame
 extension UIView {
-    
+
     var maxBoundsEstimated: CGRect {
         return CGRect(origin: .zero, size: maxSizeEstimated)
     }
-    
+
     var maxSizeEstimated: CGSize {
         return CGSize(width: maxWidthEstimated, height: maxHeightEstimated)
     }
-    
+
     var maxWidthEstimated: CGFloat {
         let constraintsWidth = constraints.filter({ $0.firstAttribute == NSLayoutAttribute.width })
-        return max(between: frame.size.width, andContantsOf: constraintsWidth)
+        return max(between: frame.size.width, andConstantsOf: constraintsWidth)
     }
-    
+
     var maxHeightEstimated: CGFloat {
         let constraintsHeight = constraints.filter({ $0.firstAttribute == NSLayoutAttribute.height })
-        return max(between: frame.size.height, andContantsOf: constraintsHeight)
+        return max(between: frame.size.height, andConstantsOf: constraintsHeight)
     }
-    
-    private func max(between value: CGFloat, andContantsOf constraints: [NSLayoutConstraint]) -> CGFloat {
+
+    private func max(between value: CGFloat, andConstantsOf constraints: [NSLayoutConstraint]) -> CGFloat {
         let max = constraints.reduce(value, { max, constraint in
             var tempMax = max
             if constraint.constant > tempMax { tempMax = constraint.constant }

--- a/Sources/Extensions/UIView+IBInspectable.swift
+++ b/Sources/Extensions/UIView+IBInspectable.swift
@@ -44,7 +44,7 @@ extension UIView {
         set { objc_setAssociatedObject(self, &AssociatedKeys.status, newValue, AssociationPolicy.retain.objc) }
     }
 
-    var skeletonable: Bool! {
+    fileprivate var skeletonable: Bool! {
         get { return objc_getAssociatedObject(self, &AssociatedKeys.skeletonable) as? Bool ?? false }
         set { objc_setAssociatedObject(self, &AssociatedKeys.skeletonable, newValue, AssociationPolicy.retain.objc) }
     }

--- a/Sources/Extensions/UIView+IBInspectable.swift
+++ b/Sources/Extensions/UIView+IBInspectable.swift
@@ -15,38 +15,37 @@ private enum AssociatedKeys {
 }
 
 public extension UIView {
-    
+
     @IBInspectable
     var isSkeletonable: Bool {
         get { return skeletonable }
         set { skeletonable = newValue }
     }
-    
+
     var isSkeletonActive: Bool {
         return status == .on || (subviewsSkeletonables.first(where: { $0.isSkeletonActive }) != nil)
     }
 }
 
 extension UIView {
-    
+
     enum Status {
         case on
         case off
     }
-    
+
     var skeletonLayer: SkeletonLayer? {
         get { return objc_getAssociatedObject(self, &AssociatedKeys.skeletonLayer) as? SkeletonLayer }
         set { objc_setAssociatedObject(self, &AssociatedKeys.skeletonLayer, newValue, AssociationPolicy.retain.objc) }
     }
-    
+
     var status: Status! {
         get { return objc_getAssociatedObject(self, &AssociatedKeys.status) as? Status ?? .off }
         set { objc_setAssociatedObject(self, &AssociatedKeys.status, newValue, AssociationPolicy.retain.objc) }
     }
 
-    private var skeletonable: Bool! {
+    var skeletonable: Bool! {
         get { return objc_getAssociatedObject(self, &AssociatedKeys.skeletonable) as? Bool ?? false }
         set { objc_setAssociatedObject(self, &AssociatedKeys.skeletonable, newValue, AssociationPolicy.retain.objc) }
     }
 }
-

--- a/Sources/Helpers/AssociationPolicy.swift
+++ b/Sources/Helpers/AssociationPolicy.swift
@@ -16,7 +16,7 @@ enum AssociationPolicy: UInt {
     case copyNonatomic = 3
     case retain = 769
     case retainNonatomic = 1
-    
+
     var objc: objc_AssociationPolicy {
         return objc_AssociationPolicy(rawValue: rawValue)!
     }

--- a/Sources/Helpers/ContainsMultilineText.swift
+++ b/Sources/Helpers/ContainsMultilineText.swift
@@ -17,7 +17,7 @@ extension ContainsMultilineText {
 }
 
 extension UILabel: ContainsMultilineText {
-    var numLines: Int { 
+    var numLines: Int {
         return numberOfLines
     }
 }

--- a/Sources/Helpers/PrepareForSkeletonProtocol.swift
+++ b/Sources/Helpers/PrepareForSkeletonProtocol.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 protocol PrepareForSkeleton {
-    func prepareViewForSkeleton() 
+    func prepareViewForSkeleton()
 }
 
 extension UILabel: PrepareForSkeleton {

--- a/Sources/Helpers/RecursiveProtocol.swift
+++ b/Sources/Helpers/RecursiveProtocol.swift
@@ -11,15 +11,16 @@ import UIKit
 typealias VoidBlock = () -> Void
 typealias RecursiveBlock<T> = (T) -> Void
 
-//MARK: Recursive
+// MARK: Recursive
+
 protocol Recursive {
-    associatedtype Element 
-    func recursiveSearch(inArray array:[Element], leafBlock: VoidBlock, recursiveBlock: RecursiveBlock<Element>)
+    associatedtype Element
+    func recursiveSearch(inArray array: [Element], leafBlock: VoidBlock, recursiveBlock: RecursiveBlock<Element>)
 }
 
 extension Recursive {
-    func recursiveSearch(inArray array:[Element], leafBlock: VoidBlock, recursiveBlock: RecursiveBlock<Element>) {
-        guard array.count > 0 else {
+    func recursiveSearch(inArray array: [Element], leafBlock: VoidBlock, recursiveBlock: RecursiveBlock<Element>) {
+        guard !array.isEmpty else {
             leafBlock()
             return
         }
@@ -33,5 +34,3 @@ extension UIView: Recursive {
 extension CALayer: Recursive {
     typealias Element = CALayer
 }
-
-

--- a/Sources/SkeletonDefaultConfig.swift
+++ b/Sources/SkeletonDefaultConfig.swift
@@ -9,12 +9,12 @@
 import UIKit
 
 public enum SkeletonDefaultConfig {
-    
+
     public static let tintColor = UIColor.clouds
-    
+
     public static let gradient = SkeletonGradient(baseColor: tintColor)
-    
+
     public static let multilineHeight = 15
-    
+
     public static let multilineSpacing = 10
 }

--- a/Sources/SkeletonGradient.swift
+++ b/Sources/SkeletonGradient.swift
@@ -9,13 +9,13 @@
 import UIKit
 
 public struct SkeletonGradient {
-    
+
     private var gradientColors: [UIColor]
-    
+
     public var colors: [UIColor] {
         return gradientColors
     }
-    
+
     public init(baseColor: UIColor, secondaryColor: UIColor? = nil) {
         if let secondary = secondaryColor {
             self.gradientColors = [baseColor, secondary, baseColor]

--- a/Sources/SkeletonLayer.swift
+++ b/Sources/SkeletonLayer.swift
@@ -8,13 +8,13 @@
 
 import UIKit
 
-class SkeletonLayerFactory {
-    
-    func makeLayer(withType type: SkeletonType, usingColors colors: [UIColor], andHolder holder: UIView) -> SkeletonLayer {
+final class SkeletonLayerFactory {
+
+    static func makeLayer(withType type: SkeletonType, usingColors colors: [UIColor], andHolder holder: UIView) -> SkeletonLayer {
         return SkeletonLayer(withType: type, usingColors: colors, andSkeletonHolder: holder)
     }
-    
-    func makeMultilineLayer(withType type: SkeletonType, for index: Int, width: Int) -> CALayer {
+
+    static func makeMultilineLayer(withType type: SkeletonType, for index: Int, width: Int) -> CALayer {
         let spaceRequitedForEachLine = SkeletonDefaultConfig.multilineHeight + SkeletonDefaultConfig.multilineSpacing
         let layer = type.layer
         layer.anchorPoint = .zero
@@ -29,7 +29,7 @@ public typealias SkeletonLayerAnimation = (CALayer) -> CAAnimation
 public enum SkeletonType {
     case solid
     case gradient
-    
+
     var layer: CALayer {
         switch self {
         case .solid:
@@ -38,7 +38,7 @@ public enum SkeletonType {
             return CAGradientLayer()
         }
     }
-    
+
     var layerAnimation: SkeletonLayerAnimation {
         switch self {
         case .solid:
@@ -49,19 +49,19 @@ public enum SkeletonType {
     }
 }
 
-struct SkeletonLayer {
-    
+public struct SkeletonLayer {
+
     private var maskLayer: CALayer
     private weak var holder: UIView?
-    
+
     var type: SkeletonType {
         return maskLayer is CAGradientLayer ? .gradient : .solid
     }
-    
+
     var contentLayer: CALayer {
         return maskLayer
     }
-    
+
     init(withType type: SkeletonType, usingColors colors: [UIColor], andSkeletonHolder holder: UIView) {
         self.holder = holder
         self.maskLayer = type.layer
@@ -70,11 +70,16 @@ struct SkeletonLayer {
         addMultilinesIfNeeded()
         self.maskLayer.tint(withColors: colors)
     }
-    
+
+    func updateLayer() {
+        guard let holder = holder else { return }
+        maskLayer.bounds = holder.maxBoundsEstimated
+    }
+
     func removeLayer() {
         maskLayer.removeFromSuperlayer()
     }
-    
+
     func addMultilinesIfNeeded() {
         guard let multiLineView = holder as? ContainsMultilineText else { return }
         maskLayer.addMultilinesLayers(lines: multiLineView.numLines, type: type)
@@ -87,7 +92,7 @@ extension SkeletonLayer {
         let animation = anim ?? type.layerAnimation
         contentLayer.playAnimation(animation, key: "skeletonAnimation")
     }
-    
+
     func stopAnimation() {
         contentLayer.stopAnimation(forKey: "skeletonAnimation")
     }

--- a/Sources/SkeletonView.swift
+++ b/Sources/SkeletonView.swift
@@ -68,14 +68,14 @@ extension UIView {
                         })
     }
 
-    func startSkeletonLayerAnimationBlock(_ anim: SkeletonLayerAnimation? = nil) -> VoidBlock {
+    fileprivate func startSkeletonLayerAnimationBlock(_ anim: SkeletonLayerAnimation? = nil) -> VoidBlock {
         return {
             guard let layer = self.skeletonLayer else { return }
             layer.start(anim)
         }
     }
 
-    var stopSkeletonLayerAnimationBlock: VoidBlock {
+    fileprivate var stopSkeletonLayerAnimationBlock: VoidBlock {
         return {
             guard let layer = self.skeletonLayer else { return }
             layer.stopAnimation()

--- a/Sources/SkeletonView.swift
+++ b/Sources/SkeletonView.swift
@@ -9,23 +9,23 @@
 import UIKit
 
 public extension UIView {
-    
+
     func showSkeleton(usingColor color: UIColor = SkeletonDefaultConfig.tintColor) {
         showSkeleton(withType: .solid, usingColors: [color])
     }
-    
+
     func showGradientSkeleton(usingGradient gradient: SkeletonGradient = SkeletonDefaultConfig.gradient) {
         showSkeleton(withType: .gradient, usingColors: gradient.colors)
     }
-    
+
     func showAnimatedSkeleton(usingColor color: UIColor = SkeletonDefaultConfig.tintColor, animation: SkeletonLayerAnimation? = nil) {
         showSkeleton(withType: .solid, usingColors: [color], animated: true, animation: animation)
     }
-    
+
     func showAnimatedGradientSkeleton(usingGradient gradient: SkeletonGradient = SkeletonDefaultConfig.gradient, animation: SkeletonLayerAnimation? = nil) {
         showSkeleton(withType: .gradient, usingColors: gradient.colors, animated: true, animation: animation)
     }
-    
+
     func hideSkeleton(reloadDataAfter reload: Bool = true) {
         removeDummyDataSourceIfNeeded(reloadAfter: reload)
         recursiveSearch(inArray: subviewsSkeletonables,
@@ -34,10 +34,10 @@ public extension UIView {
                             $0.hideSkeleton(reloadDataAfter: reload)
                         })
     }
-    
+
     func startSkeletonAnimation(_ anim: SkeletonLayerAnimation? = nil) {
         recursiveSearch(inArray: subviewsSkeletonables,
-                        leafBlock:  startSkeletonLayerAnimationBlock(anim)) {
+                        leafBlock: startSkeletonLayerAnimationBlock(anim)) {
                             $0.startSkeletonAnimation(anim)
                         }
     }
@@ -51,27 +51,31 @@ public extension UIView {
 }
 
 extension UIView {
-    
+
     func showSkeleton(withType type: SkeletonType = .solid, usingColors colors: [UIColor], animated: Bool = false, animation: SkeletonLayerAnimation? = nil) {
         addDummyDataSourceIfNeeded()
         recursiveSearch(inArray: subviewsSkeletonables,
                         leafBlock: {
-                            guard !isSkeletonActive else { return }
-                            (self as? PrepareForSkeleton)?.prepareViewForSkeleton()
-                            addSkeletonLayer(withType: type, usingColors: colors, animated: animated, animation: animation)
-                        }) {
+                            if isSkeletonActive {
+                                updateSkeletonLayer()
+                            } else {
+                                (self as? PrepareForSkeleton)?.prepareViewForSkeleton()
+                                addSkeletonLayer(withType: type, usingColors: colors, animated: animated, animation: animation)
+                            }
+                        },
+                        recursiveBlock: {
                             $0.showSkeleton(withType: type, usingColors: colors, animated: animated, animation: animation)
-                        }
+                        })
     }
-    
-    private func startSkeletonLayerAnimationBlock(_ anim: SkeletonLayerAnimation? = nil) -> VoidBlock {
+
+    func startSkeletonLayerAnimationBlock(_ anim: SkeletonLayerAnimation? = nil) -> VoidBlock {
         return {
             guard let layer = self.skeletonLayer else { return }
             layer.start(anim)
         }
     }
-    
-    private var stopSkeletonLayerAnimationBlock: VoidBlock {
+
+    var stopSkeletonLayerAnimationBlock: VoidBlock {
         return {
             guard let layer = self.skeletonLayer else { return }
             layer.stopAnimation()
@@ -91,7 +95,7 @@ extension UITableView {
     }
 }
 
-extension UITableViewCell {
+public extension UITableViewCell {
     override var subviewsSkeletonables: [UIView] {
         return contentView.subviews.filter { $0.isSkeletonable }
     }
@@ -104,21 +108,24 @@ extension UIStackView {
 }
 
 extension UIView {
-    
+
     func addSkeletonLayer(withType type: SkeletonType, usingColors colors: [UIColor], animated: Bool, animation: SkeletonLayerAnimation? = nil) {
-        self.skeletonLayer = SkeletonLayerFactory().makeLayer(withType: type, usingColors: colors, andHolder: self)
+        self.skeletonLayer = SkeletonLayerFactory.makeLayer(withType: type, usingColors: colors, andHolder: self)
         layer.insertSublayer(skeletonLayer!.contentLayer, at: UInt32.max)
         if animated { skeletonLayer!.start(animation) }
         status = .on
     }
-    
+
+    func updateSkeletonLayer() {
+        guard let skLayer = skeletonLayer else { return }
+        skLayer.updateLayer()
+    }
+
     func removeSkeletonLayer() {
-        guard isSkeletonActive,
-            let layer = skeletonLayer else { return }
+        guard isSkeletonActive, let layer = skeletonLayer else { return }
         layer.stopAnimation()
         layer.removeLayer()
         skeletonLayer = nil
         status = .off
     }
 }
-


### PR DESCRIPTION
Using `SkeletonView` (version 1.0.1) in a Swift 4 based project is not possible, because you're getting compile errors:

```
tableView.skeletonDataSource = dataSource
```

Error:(123, 19) 'skeletonDataSource' is inaccessible due to 'internal' protection level

```
$ swift --version
Apple Swift version 4.0.2 (swiftlang-900.0.69.2 clang-900.0.38)
Target: x86_64-apple-macosx10.9
```
