### PR TITLE
Removed wrapping structs to NSValue

### DIFF
--- a/Sources/Extensions/CALayer+Extensions.swift
+++ b/Sources/Extensions/CALayer+Extensions.swift
@@ -68,12 +68,12 @@ public extension CALayer {
     
     var sliding: CAAnimation {
         let startPointAnim = CABasicAnimation(keyPath: #keyPath(CAGradientLayer.startPoint))
-        startPointAnim.fromValue = NSValue(cgPoint:CGPoint(x: -1, y: 0.5))
-        startPointAnim.toValue = NSValue(cgPoint:CGPoint(x:1, y: 0.5))
+        startPointAnim.fromValue = CGPoint(x: -1, y: 0.5)
+        startPointAnim.toValue = CGPoint(x:1, y: 0.5)
         
         let endPointAnim = CABasicAnimation(keyPath: #keyPath(CAGradientLayer.endPoint))
-        endPointAnim.fromValue = NSValue(cgPoint:CGPoint(x: 0, y: 0.5))
-        endPointAnim.toValue = NSValue(cgPoint:CGPoint(x:2, y: 0.5))
+        endPointAnim.fromValue = CGPoint(x: 0, y: 0.5)
+        endPointAnim.toValue = CGPoint(x:2, y: 0.5)
         
         let animGroup = CAAnimationGroup()
         animGroup.animations = [startPointAnim, endPointAnim]

--- a/Sources/SkeletonAnimationBuilder.swift
+++ b/Sources/SkeletonAnimationBuilder.swift
@@ -66,12 +66,12 @@ public class SkeletonAnimationBuilder {
         return { layer in
             
             let startPointAnim = CABasicAnimation(keyPath: #keyPath(CAGradientLayer.startPoint))
-            startPointAnim.fromValue = NSValue(cgPoint: direction.startPoint.from)
-            startPointAnim.toValue = NSValue(cgPoint: direction.startPoint.to)
+            startPointAnim.fromValue = direction.startPoint.from
+            startPointAnim.toValue = direction.startPoint.to
             
             let endPointAnim = CABasicAnimation(keyPath: #keyPath(CAGradientLayer.endPoint))
-            endPointAnim.fromValue = NSValue(cgPoint: direction.endPoint.from)
-            endPointAnim.toValue = NSValue(cgPoint: direction.endPoint.to)
+            endPointAnim.fromValue = direction.endPoint.from
+            endPointAnim.toValue = direction.endPoint.to
             
             let animGroup = CAAnimationGroup()
             animGroup.animations = [startPointAnim, endPointAnim]


### PR DESCRIPTION
Removed wrapping CGPoint to NSValue of from/to CABasicAnimation parameters because it's not necessary in Swift