### PR TITLE
Add config to enable / disable making the last line in a skeleton-text-view shorter

### DIFF
--- a/Sources/Extensions/CALayer+Extensions.swift
+++ b/Sources/Extensions/CALayer+Extensions.swift
@@ -39,7 +39,11 @@ extension CALayer {
     func addMultilinesLayers(lines: Int, type: SkeletonType) {
         let numberOfSublayers = calculateNumLines(maxLines: lines)
         for index in 0..<numberOfSublayers {
-            let layer = SkeletonLayerFactory().makeMultilineLayer(withType: type, for: index, width: Int(bounds.width))
+            var width = Int(bounds.width)
+            if SkeletonDefaultConfig.multilineLastLineShorter && index == numberOfSublayers-1 && numberOfSublayers != 1 {
+                width -= Int(Double(width)*0.2);
+            }
+            let layer = SkeletonLayerFactory().makeMultilineLayer(withType: type, for: index, width: width)
             addSublayer(layer)
         }
     }

--- a/Sources/SkeletonDefaultConfig.swift
+++ b/Sources/SkeletonDefaultConfig.swift
@@ -17,4 +17,6 @@ public enum SkeletonDefaultConfig {
     public static let multilineHeight = 15
     
     public static let multilineSpacing = 10
+    
+    public static let multilineLastLineShorter = true
 }


### PR DESCRIPTION
This is my first touch with Swift, so the extension heavy code is kind of confusing to be honest so I hope I didn't take some shortcut I shouldn't have. I'm fine with making revisions but in that case do recommend where in the code it should be placed.

I made the config true by default, which is kind of opinionated on my end in hindsight. Can update it if you don't agree with it (I suppose it could "break" apps using the framework already when they update).

I made it so that it doesn't shorten one-liners as well.

Here's a screenshot: ![img_9702](https://user-images.githubusercontent.com/899947/33016584-ad531a5c-ce21-11e7-908d-5355dae7cb23.PNG)
