### PR TITLE
Revert wrong README change

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ You can set some properties for multilines elements.
   - values: `0...100`
   - default: `70%`
 - **Corner radius** of lines. (**NEW**)
-  - values: `0...10
+  - values: `0...10`
   - default: `0`
 
 To modify the percent or radius **using code**, set the properties:


### PR DESCRIPTION
I've just reverted a missing ` in the README in this commit https://github.com/Juanpe/SkeletonView/commit/c06ae2d72c640a8fddf520991f3a3b274ad91ffd