### PR TITLE
Use Stack View to Calculate Bounds

### DIFF
--- a/Sources/Extensions/UIView+Frame.swift
+++ b/Sources/Extensions/UIView+Frame.swift
@@ -12,6 +12,18 @@ import UIKit
 extension UIView {
     
     var maxBoundsEstimated: CGRect {
+        if let parentStackView = (superview as? UIStackView) {
+            var origin: CGPoint = .zero
+            switch parentStackView.alignment {
+            case .center:
+                origin.x = maxWidthEstimated / 2
+            case .trailing:
+                origin.x = maxWidthEstimated
+            default:
+                break
+            }
+            return CGRect(origin: origin, size: maxSizeEstimated)
+        }
         return CGRect(origin: .zero, size: maxSizeEstimated)
     }
     


### PR DESCRIPTION
Labels inside of stack views are not aligned properly
because we were assuming leading alignment.
Calculating the origin based off of the stack view alignment
instead.
https://github.com/Juanpe/SkeletonView/issues/76

Before:
https://media.giphy.com/media/2WH6TiyiF9VTi3r0QD/giphy.gif
After: 
https://media.giphy.com/media/fx2jBbOA8E6G1MIEgk/giphy.gif