### PR TITLE
Fix typos in README and method signature

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -136,7 +136,7 @@ extension ViewController: SkeletonTableViewDataSource {
         return 9
     }
     
-    func collectionSkeletonView(_ skeletonView: UITableView, cellIdenfierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier {
+    func collectionSkeletonView(_ skeletonView: UITableView, cellIdentifierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier {
         return "CellIdentifier"
     }
     

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Enjoy it! 🙂
   * [Hierarchy](#-hierarchy)
 * [Documentation](#-documentation)
 * [Next steps](#-next-steps)
-* [Contributed](#-contributed)
+* [Contributing](#-contributing)
 * [Mentions](#-mentions)
 * [Author](#-author)
 * [License](#-license)
@@ -315,7 +315,7 @@ view.showAnimatedGradientSkeleton(usingGradient: gradient, animation: animation)
 |------- | -------
 | .leftRight | ![](Assets/sliding_left_to_right.gif)
 | .rightLeft | ![](Assets/sliding_right_to_left.gif)
-| .topBottom | ![](Assets/sliding_top_to_bottom.gif)  
+| .topBottom | ![](Assets/sliding_top_to_bottom.gif)
 | .bottomTop | ![](Assets/sliding_bottom_to_top.gif)
 | .topLeftBottomRight | ![](Assets/sliding_topLeft_to_bottomRight.gif)
 | .bottomRightTopLeft | ![](Assets/sliding_bottomRight_to_topLeft.gif)
@@ -356,7 +356,7 @@ Coming soon...😅
 * [ ] Add animations when it shows/hides the skeletons
 * [ ] MacOS and WatchOS compatible
 
-## ❤️ Contributed
+## ❤️ Contributing
 This is an open source project, so feel free to contribute. How?
 - Open an [issue](https://github.com/Juanpe/SkeletonView/issues/new).
 - Send feedback via [email](mailto://juanpecatalan.com).

--- a/Sources/Collections/SkeletonCollectionDataSource.swift
+++ b/Sources/Collections/SkeletonCollectionDataSource.swift
@@ -36,7 +36,7 @@ extension SkeletonCollectionDataSource: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cellIdentifier = originalTableViewDataSource?.collectionSkeletonView(tableView, cellIdenfierForRowAt: indexPath) ?? ""
+        let cellIdentifier = originalTableViewDataSource?.collectionSkeletonView(tableView, cellIdentifierForRowAt: indexPath) ?? ""
         let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
         return cell
     }

--- a/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
+++ b/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
@@ -11,7 +11,7 @@ import UIKit
 public protocol SkeletonTableViewDataSource: UITableViewDataSource {
     func numSections(in collectionSkeletonView: UITableView) -> Int
     func collectionSkeletonView(_ skeletonView: UITableView, numberOfRowsInSection section: Int) -> Int
-    func collectionSkeletonView(_ skeletonView: UITableView, cellIdenfierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier
+    func collectionSkeletonView(_ skeletonView: UITableView, cellIdentifierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier
 }
 
 public extension SkeletonTableViewDataSource {

--- a/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
+++ b/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
@@ -21,6 +21,13 @@ public extension SkeletonTableViewDataSource {
     }
     
     func numSections(in collectionSkeletonView: UITableView) -> Int { return 1 }
+
+    /// Keeping the misspelled version around until it can be deprecated
+    /// Right now, it just calls the new correctly spelled method and returns its result
+    @available(*, deprecated, renamed: "collectionSkeletonView(_:cellIdentifierForRowAt:)")
+    func collectionSkeletonView(_ skeletonView: UITableView, cellIdenfierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier {
+        return collectionSkeletonView(skeletonView, cellIdentifierForRowAt: indexPath)
+    }
 }
 
 public protocol SkeletonTableViewDelegate: UITableViewDelegate {


### PR DESCRIPTION
This PR just fixes a couple typos that I noticed:

- Change "Contributed" to "Contributing" in `README.md`
- Fix spelling in `collectionSkeletonView` method (`cellIdenfierForRowAt` → `cellIdentifierForRowAt`), and update references to it
- Add a default implementation for the deprecated method which calls the new method and returns its result

Thank you for SkeletonView! It's proven very useful for me, and easy to use!