### PR TITLE
#86 disableUserInteraction() on UIScrollView just to prevent scroll

### DIFF
--- a/Sources/Collections/CollectionSkeletonProtocol.swift
+++ b/Sources/Collections/CollectionSkeletonProtocol.swift
@@ -28,6 +28,12 @@ extension CollectionSkeleton where Self: UIScrollView {
     var estimatedNumberOfRows: Int { return 0 }
     func addDummyDataSource() {}
     func removeDummyDataSource(reloadAfter: Bool) {}
-    func disableUserInteraction() { isUserInteractionEnabled = false }
-    func enableUserInteraction() { isUserInteractionEnabled = true }
+    
+    func disableUserInteraction() {
+        isScrollEnabled = false
+    }
+    
+    func enableUserInteraction() {
+        isScrollEnabled = true
+    }
 }


### PR DESCRIPTION
Possibly intended behavior?

I don't see any reason on a UICollection UIScrollView to prevent any interaction other than scroll.