### PR TITLE
fix: call viewForSupplementaryElementOfKind method in UICollectionView data source if needed

### DIFF
--- a/Sources/Collections/CollectionViews/SkeletonCollectionViewProtocols.swift
+++ b/Sources/Collections/CollectionViews/SkeletonCollectionViewProtocols.swift
@@ -13,6 +13,7 @@ public protocol SkeletonCollectionViewDataSource: UICollectionViewDataSource {
     func numSections(in collectionSkeletonView: UICollectionView) -> Int
     func collectionSkeletonView(_ skeletonView: UICollectionView, numberOfItemsInSection section: Int) -> Int
     func collectionSkeletonView(_ skeletonView: UICollectionView, cellIdentifierForItemAt indexPath: IndexPath) -> ReusableCellIdentifier
+    func collectionSkeletonView(_ skeletonView: UICollectionView, supplementaryViewIdentifierOfKind: String, at indexPath: IndexPath) -> String
 }
 
 public extension SkeletonCollectionViewDataSource {
@@ -22,6 +23,12 @@ public extension SkeletonCollectionViewDataSource {
     }
     
     func numSections(in collectionSkeletonView: UICollectionView) -> Int { return 1 }
+    
+    func collectionSkeletonView(_ skeletonView: UICollectionView,
+                                supplementaryViewIdentifierOfKind: String,
+                                at indexPath: IndexPath) -> String {
+        return ""
+    }
 }
 
 public protocol SkeletonCollectionViewDelegate: UICollectionViewDelegate { }

--- a/Sources/Collections/SkeletonCollectionDataSource.swift
+++ b/Sources/Collections/SkeletonCollectionDataSource.swift
@@ -58,4 +58,15 @@ extension SkeletonCollectionDataSource: UICollectionViewDataSource {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellIdentifier, for: indexPath)
         return cell
     }
+    
+    func collectionView(_ collectionView: UICollectionView,
+                        viewForSupplementaryElementOfKind kind: String,
+                        at indexPath: IndexPath) -> UICollectionReusableView {
+        let viewIdentifier = originalCollectionViewDataSource?.collectionSkeletonView(collectionView,
+                                                                                      supplementaryViewIdentifierOfKind: kind,
+                                                                                      at: indexPath) ?? ""
+        return collectionView.dequeueReusableSupplementaryView(ofKind: kind,
+                                                               withReuseIdentifier: viewIdentifier,
+                                                               for: indexPath)
+    }
 }


### PR DESCRIPTION
Hello!

Noticed that method 
```
collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath)
```
 in UICollectionViewDataSource not called when needed. 

Guess it fixes that issue