### PR TITLE
Include swift_version in podspec

### DIFF
--- a/SkeletonView.podspec
+++ b/SkeletonView.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   s.social_media_url   = "https://twitter.com/JuanpeCatalan"
   s.ios.deployment_target = "9.0"
   s.tvos.deployment_target = "9.0"
+  s.swift_version = "4.2"
   s.source       = { :git => "https://github.com/Juanpe/SkeletonView.git", :tag => s.version.to_s }
   s.source_files  = "Sources/**/*"
 end


### PR DESCRIPTION
Include swift_version in podspec.
`s.swift_version = '4.2'`

Removes need for the following code when used in projects with mixed swift versions.

```
post_install do |installer|
    installer.pods_project.targets.each do |target|
        target.build_configurations.each do |config|
            if target.name == "SkeletonView"
                config.build_settings['SWIFT_VERSION'] = '4.2'
            end
        end
    end
end
```