### PR TITLE
Fixed issue: getting wrong size of UIView.

### DIFF
--- a/Sources/SkeletonLayer.swift
+++ b/Sources/SkeletonLayer.swift
@@ -50,9 +50,12 @@ struct SkeletonLayer {
         self.holder = holder
         self.maskLayer = type.layer
         self.maskLayer.anchorPoint = .zero
-        self.maskLayer.bounds = holder.maxBoundsEstimated
-        addMultilinesIfNeeded()
-        self.maskLayer.tint(withColors: colors)
+        DispatchQueue.global(qos: .userInitiated).async { [self] in
+            DispatchQueue.main.async { [self] in
+                self.maskLayer.bounds = self.holder?.maxBoundsEstimated ?? CGRect()
+                self.maskLayer.tint(withColors: colors)
+            }
+        }
     }
     
     func removeLayer() {

--- a/Sources/SkeletonLayer.swift
+++ b/Sources/SkeletonLayer.swift
@@ -50,10 +50,11 @@ struct SkeletonLayer {
         self.holder = holder
         self.maskLayer = type.layer
         self.maskLayer.anchorPoint = .zero
+        self.maskLayer.tint(withColors: colors)
         DispatchQueue.global(qos: .userInitiated).async { [self] in
             DispatchQueue.main.async { [self] in
                 self.maskLayer.bounds = self.holder?.maxBoundsEstimated ?? CGRect()
-                self.maskLayer.tint(withColors: colors)
+                
             }
         }
     }


### PR DESCRIPTION
Hi,

I have used SkeletonView, and I figured out about this issue, and I wrote a code to help it.

In this case, I put an async because it will back to main thread only when all constraints were processed.

    init(withType type: SkeletonType, usingColors colors: [UIColor], andSkeletonHolder holder: UIView) {
        self.holder = holder
        self.maskLayer = type.layer
        self.maskLayer.anchorPoint = .zero
        DispatchQueue.global(qos: .userInitiated).async { [self] in
            DispatchQueue.main.async { [self] in
                self.maskLayer.bounds = self.holder?.maxBoundsEstimated ?? CGRect()
                self.maskLayer.tint(withColors: colors)
            }
        }
    }

I hope it fits well to help on this issue.