### PR TITLE
Add support for SwiftPM based dependency managers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "SkeletonView",
+    products: [
+        .library(name: "SkeletonView", targets: ["SkeletonView"])
+    ],
+    targets: [
+        .target(
+            name: "SkeletonView",
+            path: "Sources"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Enjoy it! 🙂
 * [Installation](#-installation)
   * [Cocoapods](#using-cocoapods)
   * [Carthage](#using-carthage)
+  * [Accio](#using-accio)
 * [How to use](#-how-to-use)
   * [Collections](#-collections)
   * [Multiline text](#-multiline-text)
@@ -87,6 +88,27 @@ Edit your `Cartfile` and specify the dependency:
 ```bash
 github "Juanpe/SkeletonView"
 ```
+
+#### Using [Accio](https://github.com/JamitLabs/Accio)
+
+Add the following to your Package.swift:
+
+```swift
+.package(url: "https://github.com/Juanpe/SkeletonView.git", .upToNextMajor(from: "1.4.2")),
+```
+
+Next, add `SkeletonView` to your App targets dependencies like so:
+
+```swift
+.target(
+    name: "App",
+    dependencies: [
+        "SkeletonView",
+    ]
+),
+```
+
+Then run `accio update`.
 
 ## 🐒 How to use
 


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.

Please note that this project is part of Accio's official [integration tests](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo/Shared/AppDependencies) within the [Demo project](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo).