### PR TITLE
Fix skeleton hierarchy

### DIFF
--- a/Example/CollectionView/Main.storyboard
+++ b/Example/CollectionView/Main.storyboard
@@ -188,6 +188,9 @@
                             <constraint firstItem="HKL-L0-T2w" firstAttribute="leading" secondItem="2Gq-Y8-1TU" secondAttribute="leading" id="iIq-cx-paX"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="2Gq-Y8-1TU"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="boolean" keyPath="isSkeletonable" value="YES"/>
+                        </userDefinedRuntimeAttributes>
                     </view>
                     <connections>
                         <outlet property="avatarImage" destination="Ql9-Jy-aWM" id="VoL-by-ygR"/>

--- a/Example/CollectionView/ViewController.swift
+++ b/Example/CollectionView/ViewController.swift
@@ -45,7 +45,6 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.isSkeletonable = true
         collectionView.prepareSkeleton(completion: { done in
             self.view.showAnimatedSkeleton()
         })

--- a/Example/TableView/Base.lproj/Main.storyboard
+++ b/Example/TableView/Base.lproj/Main.storyboard
@@ -241,7 +241,7 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="boolean" keyPath="isSkeletonable" value="NO"/>
+                            <userDefinedRuntimeAttribute type="boolean" keyPath="isSkeletonable" value="YES"/>
                         </userDefinedRuntimeAttributes>
                     </view>
                     <navigationItem key="navigationItem" id="BEI-dU-kr2"/>

--- a/Sources/SkeletonView.swift
+++ b/Sources/SkeletonView.swift
@@ -106,7 +106,7 @@ extension UIView {
     }
 
     private func recursiveShowSkeleton(skeletonConfig config: SkeletonConfig, root: UIView? = nil) {
-        guard !isSkeletonActive else { return }
+        guard !isSkeletonActive && isSkeletonable else { return }
         currentSkeletonConfig = config
         swizzleLayoutSubviews()
         addDummyDataSourceIfNeeded()


### PR DESCRIPTION
Hi @Juanpe,

I think this should fix this issue https://github.com/Juanpe/SkeletonView/issues/22

The skeleton will stop when it finds a view that is marked as not skeletonable `isSkeletonables = false`.

As mentioned here https://github.com/Juanpe/SkeletonView/issues/22, the documentation does not explain exactly how the skeleton was working. This fix makes the library behave as described in the documentation.

We should update this picture https://github.com/Juanpe/SkeletonView/blob/master/Assets/tableview_scheme.png, as with these changes, the `contentView` needs to be defined as `isSkeletonable = true`.

Let me know is this should be the intended behaviour or not.

Thanks! 🎉