### PR TITLE
【Suggestion】Spontaneous height for single line label

### DIFF
--- a/Sources/Builders/SkeletonMultilineLayerBuilder.swift
+++ b/Sources/Builders/SkeletonMultilineLayerBuilder.swift
@@ -10,6 +10,7 @@ class SkeletonMultilineLayerBuilder {
     var index: Int?
     var width: CGFloat?
     var cornerRadius: Int?
+    var eachLineHeight: CGFloat?
 
     func setSkeletonType(_ type: SkeletonType) -> SkeletonMultilineLayerBuilder {
         self.skeletonType = type
@@ -31,17 +32,23 @@ class SkeletonMultilineLayerBuilder {
         return self
     }
 
+    func setEachLineHeight(_ eachLineHeight: CGFloat) -> SkeletonMultilineLayerBuilder {
+        self.eachLineHeight = eachLineHeight
+        return self
+    }
+
     func build() -> CALayer? {
         guard let type = skeletonType,
               let index = index,
               let width = width,
-              let radius = cornerRadius
+              let radius = cornerRadius,
+              let eachLineHeight = eachLineHeight
             else { return nil }
 
         let layer = type.layer
         layer.anchorPoint = .zero
         layer.name = CALayer.skeletonSubLayersName
-        layer.updateLayerFrame(for: index, width: width)
+        layer.updateLayerFrame(for: index, width: width, height: eachLineHeight)
 
         layer.cornerRadius = CGFloat(radius)
         layer.masksToBounds = true

--- a/Sources/Extensions/CALayer+Extensions.swift
+++ b/Sources/Extensions/CALayer+Extensions.swift
@@ -44,6 +44,7 @@ extension CALayer {
         let layerBuilder = SkeletonMultilineLayerBuilder()
             .setSkeletonType(type)
             .setCornerRadius(multilineCornerRadius)
+            .setEachLineHeight(lines == 1 ? bounds.height : SkeletonAppearance.default.multilineHeight)
 
         (0..<numberOfSublayers).forEach { index in
             var width = getLineWidth(index: index, numberOfSublayers: numberOfSublayers, lastLineFillPercent: lastLineFillPercent)
@@ -60,12 +61,12 @@ extension CALayer {
         }
     }
     
-    func updateMultilinesLayers(lastLineFillPercent: Int) {
+    func updateMultilinesLayers(lines: Int, lastLineFillPercent: Int) {
         let currentSkeletonSublayers = skeletonSublayers
         let numberOfSublayers = currentSkeletonSublayers.count
         for (index, layer) in currentSkeletonSublayers.enumerated() {
             let width = getLineWidth(index: index, numberOfSublayers: numberOfSublayers, lastLineFillPercent: lastLineFillPercent)
-            layer.updateLayerFrame(for: index, width: width)
+            layer.updateLayerFrame(for: index, width: width, height: lines == 1 ? bounds.height : SkeletonAppearance.default.multilineHeight)
         }
     }
 
@@ -78,9 +79,9 @@ extension CALayer {
         return width
     }
 
-    func updateLayerFrame(for index: Int, width: CGFloat) {
-        let spaceRequiredForEachLine = SkeletonAppearance.default.multilineHeight + SkeletonAppearance.default.multilineSpacing
-        frame = CGRect(x: 0.0, y: CGFloat(index) * spaceRequiredForEachLine, width: width, height: SkeletonAppearance.default.multilineHeight)
+    func updateLayerFrame(for index: Int, width: CGFloat, height: CGFloat) {
+        let spaceRequiredForEachLine = height + SkeletonAppearance.default.multilineSpacing
+        frame = CGRect(x: 0.0, y: CGFloat(index) * spaceRequiredForEachLine, width: width, height: height)
     }
 
     private func calculateNumLines(maxLines: Int) -> Int {

--- a/Sources/SkeletonLayer.swift
+++ b/Sources/SkeletonLayer.swift
@@ -78,7 +78,7 @@ struct SkeletonLayer {
 
     func updateMultilinesIfNeeded() {
         guard let multiLineView = holder as? ContainsMultilineText else { return }
-        maskLayer.updateMultilinesLayers(lastLineFillPercent: multiLineView.lastLineFillingPercent)
+        maskLayer.updateMultilinesLayers(lines: multiLineView.numLines, lastLineFillPercent: multiLineView.lastLineFillingPercent)
     }
 }
 


### PR DESCRIPTION
I want to apply skeleton effect on a single line label like below.
<img src='https://user-images.githubusercontent.com/15883589/60230779-11c22100-98d2-11e9-8a48-a29cc44bb19b.png' width='200'>

This is a screenshot of this view.
```
UIImageView - Single line UILabel
Multi line UILabel
```

Now, SkeletonAppearance.default.multilineHeight is [used](https://github.com/Juanpe/SkeletonView/blob/master/Sources/Extensions/CALayer%2BExtensions.swift#L83) even if the [label's numberOfLines](https://github.com/Juanpe/SkeletonView/blob/master/Sources/Multilines/UILabel%2BMultiline.swift#L20) is 1.

This causes a layout issue.
<img src='https://user-images.githubusercontent.com/15883589/60231456-2f908580-98d4-11e9-9ee9-72886cfcdaaa.png' width='200'>
(Is centering constraint, but UIImageView and Single line UILabel are not centered.)

Thank you.

Or, any other solutions?