### PR TITLE
Adjust multiline behaviour to properly handle single lines

### DIFF
--- a/Sources/SkeletonLayer.swift
+++ b/Sources/SkeletonLayer.swift
@@ -70,14 +70,22 @@ struct SkeletonLayer {
     func removeLayer() {
         maskLayer.removeFromSuperlayer()
     }
-    
+
+    /// Returns a multiLineViewHolder only if the current holder implements the `ContainsMultilineText` protocol,
+    /// and actually displays multiple lines of text.
+    private var multiLineViewHolder: ContainsMultilineText? {
+        guard let multiLineView = holder as? ContainsMultilineText,
+            multiLineView.numLines != 1 else { return nil }
+        return multiLineView
+    }
+
     func addMultilinesIfNeeded() {
-        guard let multiLineView = holder as? ContainsMultilineText else { return }
+        guard let multiLineView = multiLineViewHolder else { return }
         maskLayer.addMultilinesLayers(lines: multiLineView.numLines, type: type, lastLineFillPercent: multiLineView.lastLineFillingPercent, multilineCornerRadius: multiLineView.multilineCornerRadius)
     }
 
     func updateMultilinesIfNeeded() {
-        guard let multiLineView = holder as? ContainsMultilineText else { return }
+        guard let multiLineView = multiLineViewHolder else { return }
         maskLayer.updateMultilinesLayers(lastLineFillPercent: multiLineView.lastLineFillingPercent)
     }
 }


### PR DESCRIPTION
When creating a SkeletonLayer, the current implementation will treat any UILabel as a containing multi line text. This creates situations where a label that would be a single line and has a default height is sized incorrectly, based on the `multilineHeight` set on the `default` `SkeletonAppearance`. 

In these situations where we have single line label, it's preferable to just use the bounds of the label, as this will better represent the view that is loading data.

Before | After
:---------:|:-----------:
![Before](https://user-images.githubusercontent.com/7020926/60861172-d1ad5780-a25c-11e9-86a2-b87d5056f3df.png) | ![After](https://user-images.githubusercontent.com/7020926/60861174-d6720b80-a25c-11e9-833d-05b8f0b00b2b.png)
