### PR TITLE
Update tableview cells after hiding skeleton

### DIFF
--- a/Sources/SkeletonView.swift
+++ b/Sources/SkeletonView.swift
@@ -173,7 +173,6 @@ extension UIView {
 
     private func recursiveHideSkeleton(reloadDataAfter reload: Bool, transition: SkeletonTransitionStyle, root: UIView? = nil) {
         guard isSkeletonActive else { return }
-        removeDummyDataSourceIfNeeded(reloadAfter: reload)
         currentSkeletonConfig?.transition = transition
         isUserInteractionEnabled = true
         subviewsSkeletonables.recursiveSearch(leafBlock: {
@@ -182,6 +181,8 @@ extension UIView {
         }) { subview in
             subview.recursiveHideSkeleton(reloadDataAfter: reload, transition: transition)
         }
+
+        removeDummyDataSourceIfNeeded(reloadAfter: reload)
 
         if let root = root {
             flowDelegate?.didHideSkeletons(rootView: root)


### PR DESCRIPTION
Attempt to fix: #185 

New to the repo, so not entirely sure the inner workings as to why this works, but my thought is it's now just refreshing the table view/data source later on in the function to get the expected results for #185

![giphy (1)](https://user-images.githubusercontent.com/5355231/66263156-79cab200-e7b3-11e9-9509-3141d9658bfc.gif)
