### PR TITLE
🚨  Fixed warning regarding tableView cell displaying #193

### DIFF
--- a/Example/TableView/Base.lproj/Main.storyboard
+++ b/Example/TableView/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Va7-1y-Tel">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Va7-1y-Tel">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -112,6 +112,7 @@
                                                 <constraint firstAttribute="trailingMargin" secondItem="VhU-1t-AaI" secondAttribute="trailing" constant="5" id="I7C-Bq-mfK"/>
                                                 <constraint firstItem="VhU-1t-AaI" firstAttribute="leading" secondItem="oiE-tt-nc2" secondAttribute="trailing" constant="21" id="Ojr-Kz-1k6"/>
                                                 <constraint firstItem="VhU-1t-AaI" firstAttribute="top" secondItem="7IN-F3-Mr6" secondAttribute="topMargin" constant="18" id="ZW6-JY-S4c"/>
+                                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="oiE-tt-nc2" secondAttribute="bottom" constant="7" id="nKd-kF-yyL"/>
                                             </constraints>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="boolean" keyPath="isSkeletonable" value="YES"/>

--- a/Example/TableView/ViewController.swift
+++ b/Example/TableView/ViewController.swift
@@ -42,9 +42,16 @@ class ViewController: UIViewController {
         return skeletonTypeSelector.selectedSegmentIndex == 0 ? .solid : .gradient
     }
     
+    private var didShowInitialSkeleton = false
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         tableview.isSkeletonable = true
+    }
+    
+    override func viewDidLayoutSubviews() {
+        if didShowInitialSkeleton { return }
+        didShowInitialSkeleton = true
         view.showAnimatedSkeleton()
     }
     


### PR DESCRIPTION
According to this post accessing visibleCells in viewDidLayoutSubviews() fixes this issue. https://forums.developer.apple.com/thread/117537
Because switching the skeleton on/off also calls viewDidLayoutSubviews, we only want to call this once.