### PR TITLE
Update SkeletonView.swift

### DIFF
--- a/Sources/SkeletonView.swift
+++ b/Sources/SkeletonView.swift
@@ -94,6 +94,7 @@ public extension UIView {
 
 extension UIView {
     @objc func skeletonLayoutSubviews() {
+        skeletonLayoutSubviews()
         guard isSkeletonActive else { return }
         layoutSkeletonIfNeeded()
     }


### PR DESCRIPTION
- Fixes for Issue #202 UIView.layoutSubviews swizzle is messing with standard controls
- Due to Swizzling, LayoutSubviews is not called. This fixes the issue.