### PR TITLE
Skeleton Data Source, in TableView : fix restore row height to add back the original row height

### DIFF
--- a/Example/TableView/Base.lproj/Main.storyboard
+++ b/Example/TableView/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Va7-1y-Tel">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Va7-1y-Tel">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -108,6 +108,7 @@
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="oiE-tt-nc2" firstAttribute="leading" secondItem="7IN-F3-Mr6" secondAttribute="leadingMargin" id="1be-ak-AH1"/>
+                                                <constraint firstAttribute="bottom" secondItem="oiE-tt-nc2" secondAttribute="bottom" constant="20" id="CKt-oA-eBI"/>
                                                 <constraint firstItem="oiE-tt-nc2" firstAttribute="top" secondItem="7IN-F3-Mr6" secondAttribute="topMargin" constant="7" id="EKn-ST-LDX"/>
                                                 <constraint firstAttribute="trailingMargin" secondItem="VhU-1t-AaI" secondAttribute="trailing" constant="5" id="I7C-Bq-mfK"/>
                                                 <constraint firstItem="VhU-1t-AaI" firstAttribute="leading" secondItem="oiE-tt-nc2" secondAttribute="trailing" constant="21" id="Ojr-Kz-1k6"/>

--- a/Sources/Collections/SkeletonCollectionDataSource.swift
+++ b/Sources/Collections/SkeletonCollectionDataSource.swift
@@ -14,12 +14,14 @@ class SkeletonCollectionDataSource: NSObject {
     weak var originalTableViewDataSource: SkeletonTableViewDataSource?
     weak var originalCollectionViewDataSource: SkeletonCollectionViewDataSource?
     var rowHeight: CGFloat = 0.0
+    var originalRowHeight: CGFloat = 0.0
     
-    convenience init(tableViewDataSource: SkeletonTableViewDataSource? = nil, collectionViewDataSource: SkeletonCollectionViewDataSource? = nil, rowHeight: CGFloat = 0.0) {
+    convenience init(tableViewDataSource: SkeletonTableViewDataSource? = nil, collectionViewDataSource: SkeletonCollectionViewDataSource? = nil, rowHeight: CGFloat = 0.0, originalRowHeight: CGFloat = 0.0) {
         self.init()
         self.originalTableViewDataSource = tableViewDataSource
         self.originalCollectionViewDataSource = collectionViewDataSource
         self.rowHeight = rowHeight
+        self.originalRowHeight = originalRowHeight
     }
 }
 

--- a/Sources/Collections/TableViews/UITableView+CollectionSkeleton.swift
+++ b/Sources/Collections/TableViews/UITableView+CollectionSkeleton.swift
@@ -35,9 +35,11 @@ extension UITableView: CollectionSkeleton {
         guard let originalDataSource = self.dataSource as? SkeletonTableViewDataSource,
             !(originalDataSource is SkeletonCollectionDataSource)
             else { return }
-        let rowHeight = calculateRowHeight()
+        let calculatedRowHeight = calculateRowHeight()
         let dataSource = SkeletonCollectionDataSource(tableViewDataSource: originalDataSource,
-                                                      rowHeight: rowHeight)
+                                                      rowHeight: rowHeight,
+                                                      originalRowHeight: self.rowHeight)
+        rowHeight = calculatedRowHeight
         self.skeletonDataSource = dataSource
 
         if let originalDelegate = self.delegate as? SkeletonTableViewDelegate,
@@ -74,12 +76,11 @@ extension UITableView: CollectionSkeleton {
 
     private func restoreRowHeight() {
         guard let dataSource = self.dataSource as? SkeletonCollectionDataSource else { return }
-        rowHeight = dataSource.rowHeight
+        rowHeight = dataSource.originalRowHeight
     }
     
     private func calculateRowHeight() -> CGFloat {
         guard rowHeight == UITableView.automaticDimension else { return rowHeight }
-        rowHeight = estimatedRowHeight
         return estimatedRowHeight
     }
 }


### PR DESCRIPTION
(otherwise, it just add back the calculateRowHeight, previously based on the estimated row height)

Moreover :
Avoid to change the row height in  calculateRowHeight(), because the name of the method doesn't say that, and then it just broke the utilization of the rowHeight


WARNING: from my utilization of the pod, I don't have to do anything else for UICollectionView, if you think that we must, tell me, or suggest me the idea / solution.