### PR TITLE
Offscreen table view layout issue fixed 

### DIFF
--- a/Sources/Collections/SkeletonCollectionDelegate.swift
+++ b/Sources/Collections/SkeletonCollectionDelegate.swift
@@ -41,6 +41,10 @@ extension SkeletonCollectionDelegate: UITableViewDelegate {
 
         return nil
     }
+
+    func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        cell.hideSkeleton()
+    }
 }
 
 // MARK: - UICollectionViewDelegate

--- a/Sources/Collections/SkeletonCollectionDelegate.swift
+++ b/Sources/Collections/SkeletonCollectionDelegate.swift
@@ -44,6 +44,7 @@ extension SkeletonCollectionDelegate: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         cell.hideSkeleton()
+        originalTableViewDelegate?.tableView?(tableView, didEndDisplaying: cell, forRowAt: indexPath)
     }
 }
 


### PR DESCRIPTION
1. Run test project on iPhone 5
2. Hide skeleton
AR: Some table view cells remain in skeleton state.

This happens when _showAnimatedSkeleton_ method is called from _viewDidLoad_ before views are laid out. Table view's storyboard frame may differ from the one it receives after layout. As well as the number of its visible cells. Therefore not all "skeletoned" cells become "unskeletoned"

This PR fixes the problem