### PR TITLE
Fix Issue #259: Prevent isSkeletonActive to be called when isSkeletonable is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file
 #### 🔬Improvements
   
 #### 🩹 Bug fixes
+* [**259**](https://github.com/Juanpe/SkeletonView/issues/259): Prevent isSkeletonActive to be called when isSkeletonable is false
 
 ### 📦 [1.8.6](https://github.com/Juanpe/SkeletonView/releases/tag/1.8.6)
 

--- a/Sources/SkeletonView.swift
+++ b/Sources/SkeletonView.swift
@@ -101,7 +101,7 @@ extension UIView {
 
     @objc func skeletonTraitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         skeletonTraitCollectionDidChange(previousTraitCollection)
-        guard isSkeletonActive, let config = currentSkeletonConfig else { return }
+        guard isSkeletonable, isSkeletonActive, let config = currentSkeletonConfig else { return }
         updateSkeleton(skeletonConfig: config)
     }
     
@@ -113,7 +113,7 @@ extension UIView {
     }
 
     private func recursiveShowSkeleton(skeletonConfig config: SkeletonConfig, root: UIView? = nil) {
-        guard !isSkeletonActive && isSkeletonable else { return }
+        guard isSkeletonable && !isSkeletonActive else { return }
         currentSkeletonConfig = config
         swizzleLayoutSubviews()
         swizzleTraitCollectionDidChange()


### PR DESCRIPTION
Prevent `isSkeletonActive` to be called when `isSkeletonable` is false

`isSkeletonActive`  makes a call to `subviewsSkeletonables` which in the end will call `visibleCells` of date picker's internal table view. When this happen at `traitCollectionDidChange` which somehow happen in some iOS version where the crash happened, the crash may occurs because it is trying to access a certain index of visible cell when actually it has none yet (this happens in the date pciker internally, so I'm not really sure how or why)

The changes I made is to prevent `isSkeletonActive` to be called when is it clear that the view's `isSkeletonable` is false. This should prevent the crash and also I think it also better in performance as there is no point in checking `isSkeletonActive` when it is not skeletonable