### PR TITLE
[BugFix] Fix issue on WKWebView/UIWebView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file
 #### 🔬Improvements
 
 #### 🩹 Bug fixes
+* [**271**](https://github.com/Juanpe/SkeletonView/pull/271): Fix issue when WKWebView calls skeletonLayoutSubviews not on the main thread - [@paulanatoleclaudot-betclic](https://github.com/paulanatoleclaudot-betclic)
 
 ### 📦 [1.8.7](https://github.com/Juanpe/SkeletonView/releases/tag/1.8.7)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file
 #### 🔬Improvements
 
 #### 🩹 Bug fixes
-* [**271**](https://github.com/Juanpe/SkeletonView/pull/271): Fix issue when WKWebView calls skeletonLayoutSubviews not on the main thread - [@paulanatoleclaudot-betclic](https://github.com/paulanatoleclaudot-betclic)
+* [**286**](https://github.com/Juanpe/SkeletonView/pull/286): Fix issue when WKWebView calls skeletonLayoutSubviews not on the main thread - [@paulanatoleclaudot-betclic](https://github.com/paulanatoleclaudot-betclic)
 
 ### 📦 [1.8.7](https://github.com/Juanpe/SkeletonView/releases/tag/1.8.7)
 

--- a/Sources/SkeletonView.swift
+++ b/Sources/SkeletonView.swift
@@ -94,6 +94,7 @@ public extension UIView {
 
 extension UIView {
     @objc func skeletonLayoutSubviews() {
+        guard Thread.isMainThread else { return }
         skeletonLayoutSubviews()
         guard isSkeletonActive else { return }
         layoutSkeletonIfNeeded()


### PR DESCRIPTION
Sometimes and for unknown reason, WKWebview/UIWebView calls skeletonLayoutSubviews not on the main thread, which causing NSISEngine to crash

Fatal Exception: 
NSInternalInconsistencyException Modifications to the layout engine must not be performed from a background thread after it has been accessed from the main thread.

Fatal Exception: NSInternalInconsistencyException
0  CoreFoundation                 0x18d17096c __exceptionPreprocess
1  libobjc.A.dylib                0x18ce89028 objc_exception_throw
2  Foundation                     0x18d65c5e0 -[NSISEngine tryToOptimizeReturningMutuallyExclusiveConstraints]
3  Foundation                     0x18d455854 -[NSISEngine _optimizeWithoutRebuilding]
4  Foundation                     0x18d455768 -[NSISEngine optimize]
5  Foundation                     0x18d4553d8 -[NSISEngine performPendingChangeNotifications]
6  UIKitCore                      0x1917115b8 -[UIView(Hierarchy) layoutSubviews]
7  SkeletonView                   0x1018458d4 @objc UIView.skeletonLayoutSubviews() + 98 (SkeletonView.swift:98)


Crashed: WebThread
SIGABRT ABORT 0x000000018cf5aefc
