### PR TITLE
Fix to consider the top and bottom edge insets when updating the skeleton layer height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file
 * [**292**](https://github.com/Juanpe/SkeletonView/pull/292): Fix IBInspectable support when using Carthage - [@marisalaneous](https://github.com/marisalaneous)
 * [**308**](https://github.com/Juanpe/SkeletonView/pull/308): Fix example backgroundColor in DarkMode - [@toshi0383](https://github.com/toshi0383)
 * [**307**](https://github.com/Juanpe/SkeletonView/pull/307): Prevent incorrect skeletonLayer to be added when updating skeleton - [@wsalim1610](https://github.com/wsalim1610)
+* [**319**](https://github.com/Juanpe/SkeletonView/pull/319): Fix to consider the top and bottom edge insets when updating the skeleton layer height - [@xpereta](https://github.com/xpereta)
 
 ## 📦 [1.8.7](https://github.com/Juanpe/SkeletonView/releases/tag/1.8.7)
 

--- a/Sources/Extensions/CALayer+Extensions.swift
+++ b/Sources/Extensions/CALayer+Extensions.swift
@@ -101,7 +101,7 @@ extension CALayer {
 
     func updateLayerFrame(for index: Int, size: CGSize, multilineSpacing: CGFloat, paddingInsets: UIEdgeInsets) {
         let spaceRequiredForEachLine = SkeletonAppearance.default.multilineHeight + multilineSpacing
-        frame = CGRect(x: paddingInsets.left, y: CGFloat(index) * spaceRequiredForEachLine + paddingInsets.top, width: size.width, height: size.height)
+        frame = CGRect(x: paddingInsets.left, y: CGFloat(index) * spaceRequiredForEachLine + paddingInsets.top, width: size.width, height: size.height - paddingInsets.bottom - paddingInsets.top)
     }
 
 	private func calculateNumLines(for config: SkeletonMultilinesLayerConfig) -> Int {


### PR DESCRIPTION
The .top property of skeletonPaddingInsets is being used to offset the position of the skeleton layer, but the .bottom property is left unused. As a result the skeleton layer has a larger height than expected.

To reproduce de issue using the example application we can change the header label to use a bigger font:

![Screenshot 2020-08-31 at 16 58 45](https://user-images.githubusercontent.com/21675/91741655-5243bb80-ebb5-11ea-8191-1fa7e94c5622.png)

And then add this line to configure the skeletonPaddingInsets:

```
    lazy var titleLabel: UILabel = {
        let label = UILabel()
        
        label.text = "      "
        label.font = UIFont.systemFont(ofSize: 40)
        label.isSkeletonable = true
        label.skeletonPaddingInsets = UIEdgeInsets(top: 30, left: 0, bottom: 30, right: 0)
        label.linesCornerRadius = 5
        
        return label
    }()
```

The skeleton layer is larger than expected:

![Screenshot 2020-08-31 at 16 59 11](https://user-images.githubusercontent.com/21675/91741681-5b348d00-ebb5-11ea-8330-da46c1c66af6.png)

With the change in this PR, the .bottom property is used and the skeleton layer has the expected height:

![Screenshot 2020-08-31 at 16 58 42](https://user-images.githubusercontent.com/21675/91741695-5ec81400-ebb5-11ea-8900-3117a67036b0.png)

Please tell me if I'd rather create an issue to discuss it and then add a line in the changelog if you eventually approve it.

Thanks!
