### PR TITLE
Not replace text when the skeleton disappears

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,11 +7,23 @@ disabled_rules:
   - identifier_name
   - multiple_closures_with_trailing_closure
   - class_delegate_protocol
+  - force_unwrapping
+  - force_try
+  - force_cast
+  - function_parameter_count
+  - discouraged_optional_collection
+  - shorthand_operator
+  - reduce_boolean
+  - weak_delegate
+  - nesting
+  - closure_end_indentation 
+  - function_default_parameter_at_end
+  - unowned_variable_capture
+  - legacy_constructor
 opt_in_rules:
   - multiline_arguments
   - multiline_parameters
   - closure_spacing
-  - closure_end_indentation
   - closure_body_length
   - collection_alignment
   - contains_over_filter_is_empty
@@ -27,8 +39,6 @@ opt_in_rules:
   - file_name_no_space
   - first_where
   - flatmap_over_map_reduce
-  - force_unwrapping
-  - function_default_parameter_at_end
   - implicitly_unwrapped_optional
   - joined_default_parameter
   - last_where
@@ -43,7 +53,6 @@ opt_in_rules:
   - sorted_first_last
   - switch_case_on_newline
   - unneeded_parentheses_in_closure_argument
-  - unowned_variable_capture
   - unused_declaration
   - unused_import
   - vertical_whitespace_opening_braces
@@ -51,8 +60,6 @@ opt_in_rules:
   - enum_case_associated_values_counts
   - legacy_multiple
   - legacy_random
-force_cast: error 
-force_unwrapping: error
 indentation: 2
 file_length:
  - 2500

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file
 * [**327**](https://github.com/Juanpe/SkeletonView/pull/327): Add SwiftLint - [@Juanpe](https://github.com/Juanpe)
 * [**329**](https://github.com/Juanpe/SkeletonView/pull/329): Spanish README 🇪🇸 - [@Juanpe](https://github.com/Juanpe)
 
+#### 🩹 Bug fixes
+* [**336**](https://github.com/Juanpe/SkeletonView/pull/336): Not replace text when the skeleton disappears. Solved issues: [#296](https://github.com/Juanpe/SkeletonView/issues/296), [#330](https://github.com/Juanpe/SkeletonView/issues/330) - [@Juanpe](https://github.com/Juanpe)
+
 ## 📦 [1.9](https://github.com/Juanpe/SkeletonView/releases/tag/1.9)
 
 #### 🩹 Bug fixes

--- a/Sources/Helpers/PrepareForSkeletonProtocol.swift
+++ b/Sources/Helpers/PrepareForSkeletonProtocol.swift
@@ -12,6 +12,7 @@ extension UIView {
     @objc func prepareViewForSkeleton() {
         startTransition { [weak self] in
             self?.backgroundColor = .clear
+            self?.isUserInteractionEnabled = false
         }
     }
 }
@@ -50,7 +51,6 @@ extension UIButton {
         backgroundColor = .clear
         startTransition { [weak self] in
             self?.setTitle(nil, for: .normal)
-            self?.isUserInteractionEnabled = false
         }
     }
 }

--- a/Sources/Recoverable/Recoverable.swift
+++ b/Sources/Recoverable/Recoverable.swift
@@ -24,14 +24,15 @@ extension UIView: Recoverable {
     }
     
     @objc func recoverViewState(forced: Bool) {
-        guard let safeViewState = viewState else { return }
+        guard let storedViewState = viewState else { return }
         
         startTransition { [weak self] in
-            self?.layer.cornerRadius = safeViewState.cornerRadius
-            self?.layer.masksToBounds = safeViewState.clipToBounds
+            self?.layer.cornerRadius = storedViewState.cornerRadius
+            self?.layer.masksToBounds = storedViewState.clipToBounds
+            self?.isUserInteractionEnabled = storedViewState.isUserInteractionsEnabled
             
-            if safeViewState.backgroundColor != self?.backgroundColor || forced {
-                self?.backgroundColor = safeViewState.backgroundColor
+            if self?.backgroundColor == .clear || forced {
+                self?.backgroundColor = storedViewState.backgroundColor
             }
         }
     }
@@ -51,9 +52,11 @@ extension UILabel {
     override func recoverViewState(forced: Bool) {
         super.recoverViewState(forced: forced)
         startTransition { [weak self] in
-            self?.textColor = self?.labelState?.textColor
-            self?.text = self?.labelState?.text
-            self?.isUserInteractionEnabled = self?.labelState?.isUserInteractionsEnabled ?? false
+            guard let storedLabelState = self?.labelState else { return }
+            
+            if self?.textColor == .clear || forced {
+                self?.textColor = storedLabelState.textColor
+            }
         }
     }
 }
@@ -72,9 +75,11 @@ extension UITextView {
     override func recoverViewState(forced: Bool) {
         super.recoverViewState(forced: forced)
         startTransition { [weak self] in
-            self?.textColor = self?.textState?.textColor
-            self?.text = self?.textState?.text
-            self?.isUserInteractionEnabled = self?.textState?.isUserInteractionsEnabled ?? false
+            guard let storedLabelState = self?.textState else { return }
+            
+            if self?.textColor == .clear || forced {
+                self?.textColor = storedLabelState.textColor
+            }
         }
     }
 }
@@ -112,8 +117,9 @@ extension UIButton {
     override func recoverViewState(forced: Bool) {
         super.recoverViewState(forced: forced)
         startTransition { [weak self] in
-            self?.setTitle(self?.buttonState?.title, for: .normal)
-            self?.isUserInteractionEnabled = self?.buttonState?.isUserInteractionsEnabled ?? false
+            if self?.title(for: .normal) == nil {
+                self?.setTitle(self?.buttonState?.title, for: .normal)
+            }
         }
     }
 }

--- a/Sources/Recoverable/RecoverableViewState.swift
+++ b/Sources/Recoverable/RecoverableViewState.swift
@@ -12,29 +12,25 @@ struct RecoverableViewState {
     var backgroundColor: UIColor?
     var cornerRadius: CGFloat
     var clipToBounds: Bool
+    var isUserInteractionsEnabled: Bool
     
     init(view: UIView) {
         self.backgroundColor = view.backgroundColor
         self.clipToBounds = view.layer.masksToBounds
         self.cornerRadius = view.layer.cornerRadius
+        self.isUserInteractionsEnabled = view.isUserInteractionEnabled
     }
 }
 
 struct RecoverableTextViewState {
-    var text: String?
     var textColor: UIColor?
-    var isUserInteractionsEnabled: Bool
     
     init(view: UILabel) {
         self.textColor = view.textColor
-        self.text = view.text
-        self.isUserInteractionsEnabled = view.isUserInteractionEnabled
     }
     
     init(view: UITextView) {
         self.textColor = view.textColor
-        self.text = view.text
-        self.isUserInteractionsEnabled = view.isUserInteractionEnabled
     }
 }
 
@@ -48,10 +44,8 @@ struct RecoverableImageViewState {
 
 struct RecoverableButtonViewState {
     var title: String?
-    var isUserInteractionsEnabled: Bool
     
     init(view: UIButton) {
         self.title = view.titleLabel?.text
-        self.isUserInteractionsEnabled = view.isUserInteractionEnabled
     }
 }

--- a/Sources/SkeletonConfig.swift
+++ b/Sources/SkeletonConfig.swift
@@ -22,14 +22,12 @@ struct SkeletonConfig {
     ///  Transition style
     var transition: SkeletonTransitionStyle
     
-    init(
-        type: SkeletonType,
-        colors: [UIColor],
-        gradientDirection: GradientDirection? = nil,
-        animated: Bool = false,
-        animation: SkeletonLayerAnimation? = nil,
-        transition: SkeletonTransitionStyle = .crossDissolve(0.25)
-        ) {
+    init(type: SkeletonType,
+         colors: [UIColor],
+         gradientDirection: GradientDirection? = nil,
+         animated: Bool = false,
+         animation: SkeletonLayerAnimation? = nil,
+         transition: SkeletonTransitionStyle = .crossDissolve(0.25)) {
         self.type = type
         self.colors = colors
         self.gradientDirection = gradientDirection


### PR DESCRIPTION
Fixes #296, #330 

### Summary

**SkeletonView** saves the view state of all skeletonable elements. Why? it needs to hide some texts and to change colors to skeleton looks fine. 
The problem is if the user modifies the saved values before to hide the skeleton when the skeleton disappears, all these values will be replaced.

For now, the solution is not to save the content of these elements, only properties related to the appearance, as the `textColor`. When the skeleton disappears, if the color is not equal to the value set when the skeleton appears, the color will be recovered.

### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/develop/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/develop/CODE_OF_CONDUCT.md).
