### PR TITLE
Fix incorrect padding and multiline layer frame calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file
 ### Next version
 
 #### 🙌 New
+* [**340**](https://github.com/Juanpe/SkeletonView/pull/340): Fixed incorrect padding, and incorrect multiline layer frame calculation - [@yzhao198](https://github.com/yzhao198)
 * [**339**](https://github.com/Juanpe/SkeletonView/pull/339): Add `hiddenWhenSkeletonIsActive` property - [@mohn93](https://github.com/mohn93)
 * [**341**](https://github.com/Juanpe/SkeletonView/pull/341): Support autoreverses in gradient animations - [@Juanpe](https://github.com/Juanpe)
 

--- a/Sources/Extensions/CALayer+Extensions.swift
+++ b/Sources/Extensions/CALayer+Extensions.swift
@@ -41,9 +41,9 @@ struct SkeletonMultilinesLayerConfig {
     /// Returns padding insets taking into account if the RTL is activated
     var calculatedPaddingInsets: UIEdgeInsets {
         UIEdgeInsets(top: paddingInsets.top,
-                     left: paddingInsets.right,
+                     left: isRTL ? paddingInsets.right : paddingInsets.left,
                      bottom: paddingInsets.bottom,
-                     right: paddingInsets.left)
+                     right: isRTL ? paddingInsets.left : paddingInsets.right)
     }
 }
 
@@ -117,7 +117,7 @@ extension CALayer {
         let newFrame = CGRect(x: paddingInsets.left,
                               y: CGFloat(index) * spaceRequiredForEachLine + paddingInsets.top,
                               width: size.width,
-                              height: size.height - paddingInsets.bottom - paddingInsets.top)
+                              height: size.height)
         
         frame = flipRectForRTLIfNeeded(newFrame, isRTL: isRTL)
     }


### PR DESCRIPTION
### Summary

Thank you for writing this library. Here is a snippet of code I used when testing `SkeletonView`:

```Swift
import UIKit
import SkeletonView

class ViewController: UIViewController {

    private lazy var label: UILabel = {
        let label = UILabel()
        label.translatesAutoresizingMaskIntoConstraints = false
        label.numberOfLines = 2
        label.skeletonLineSpacing = 8
        label.font = .systemFont(ofSize: 10)
        label.lastLineFillPercent = 50
        label.skeletonPaddingInsets = .init(top: 12, left: 0, bottom: 12, right: 30)
        label.isSkeletonable = true
        
        return label
    }()
    
    override func viewDidLoad() {
        super.viewDidLoad()
        
        view.backgroundColor = .white
        
        SkeletonAppearance.default.multilineHeight = 12
        
        view.addSubview(label)
        
        label.heightAnchor.constraint(equalToConstant: 54).isActive = true
        label.widthAnchor.constraint(equalToConstant: 250).isActive = true
        label.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
        label.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
        
        view.isSkeletonable = true
        view.showSkeleton()
    }
}
```

The desired result should be

<img width="314" alt="Screen Shot 2020-10-08 at 8 30 09 PM" src="https://user-images.githubusercontent.com/15700329/95536205-a9ecf800-09a7-11eb-99d7-1689a93828a5.png">

but the current version (1.10.0) gives me

<img width="252" alt="Screen Shot 2020-10-08 at 8 34 58 PM" src="https://user-images.githubusercontent.com/15700329/95536260-d6a10f80-09a7-11eb-8b39-8fb344b6adfe.png">

Given my testing device is NOT RTL, it is clear the padding is incorrectly rendered. After the changes made in this MR, the desired result is achieved.

### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/develop/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/develop/CODE_OF_CONDUCT.md).
