### PR TITLE
Support autoreverses in gradient animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file
 
 #### 🙌 New
 * [**339**](https://github.com/Juanpe/SkeletonView/pull/339): Add `hiddenWhenSkeletonIsActive` property - [@mohn93](https://github.com/mohn93)
+* [**341**](https://github.com/Juanpe/SkeletonView/pull/341): Support autoreverses in gradient animations - [@Juanpe](https://github.com/Juanpe)
 
 ## 📦 [1.10.0](https://github.com/Juanpe/SkeletonView/releases/tag/1.10.0)
 

--- a/Sources/Extensions/CALayer+Extensions.swift
+++ b/Sources/Extensions/CALayer+Extensions.swift
@@ -153,25 +153,6 @@ public extension CALayer {
         return pulseAnimation
     }
     
-//    var sliding: CAAnimation {
-//        let startPointAnim = CABasicAnimation(keyPath: #keyPath(CAGradientLayer.startPoint))
-//        startPointAnim.fromValue = CGPoint(x: -1, y: 0.5)
-//        startPointAnim.toValue = CGPoint(x: 1, y: 0.5)
-//
-//        let endPointAnim = CABasicAnimation(keyPath: #keyPath(CAGradientLayer.endPoint))
-//        endPointAnim.fromValue = CGPoint(x: 0, y: 0.5)
-//        endPointAnim.toValue = CGPoint(x: 2, y: 0.5)
-//
-//        let animGroup = CAAnimationGroup()
-//        animGroup.animations = [startPointAnim, endPointAnim]
-//        animGroup.duration = 1.5
-//        animGroup.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeIn)
-//        animGroup.repeatCount = .infinity
-//        animGroup.isRemovedOnCompletion = false
-//
-//        return animGroup
-//    }
-    
     func playAnimation(_ anim: SkeletonLayerAnimation, key: String, completion: (() -> Void)? = nil) {
         skeletonSublayers.recursiveSearch(leafBlock: {
             DispatchQueue.main.async { CATransaction.begin() }

--- a/Sources/SkeletonAnimationBuilder.swift
+++ b/Sources/SkeletonAnimationBuilder.swift
@@ -18,8 +18,8 @@ public enum GradientDirection {
     case topLeftBottomRight
     case bottomRightTopLeft
     
-    public func slidingAnimation(duration: CFTimeInterval = 1.5) -> SkeletonLayerAnimation {
-        return SkeletonAnimationBuilder().makeSlidingAnimation(withDirection: self, duration: duration)
+    public func slidingAnimation(duration: CFTimeInterval = 1.5, autoreverses: Bool = false) -> SkeletonLayerAnimation {
+        return SkeletonAnimationBuilder().makeSlidingAnimation(withDirection: self, duration: duration, autoreverses: autoreverses)
     }
 
     // codebeat:disable[ABC]
@@ -62,7 +62,7 @@ public enum GradientDirection {
 public class SkeletonAnimationBuilder {
     public init() { }
     
-    public func makeSlidingAnimation(withDirection direction: GradientDirection, duration: CFTimeInterval = 1.5) -> SkeletonLayerAnimation {
+    public func makeSlidingAnimation(withDirection direction: GradientDirection, duration: CFTimeInterval = 1.5, autoreverses: Bool = false) -> SkeletonLayerAnimation {
         return { layer in
             let startPointAnim = CABasicAnimation(keyPath: #keyPath(CAGradientLayer.startPoint))
             startPointAnim.fromValue = direction.startPoint.from
@@ -77,6 +77,7 @@ public class SkeletonAnimationBuilder {
             animGroup.duration = duration
             animGroup.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeIn)
             animGroup.repeatCount = .infinity
+            animGroup.autoreverses = autoreverses
             animGroup.isRemovedOnCompletion = false
             
             return animGroup


### PR DESCRIPTION
Fixes #278 

### Summary

Now, for gradient skeletons, we can decide if the animation has `autoreverses` property enabled or not. If this property is `true`
 the animation will be played with a ping-pong effect.

**Preview:**
![autoreverses](https://user-images.githubusercontent.com/1409041/96428905-9ab84680-1200-11eb-9ed6-c992d41413b6.gif)

**How to use:**
When launching the skeleton call, you need to specify this property, here an example:
```
view.showAnimatedGradientSkeleton(animation: GradientDirection.leftRight.slidingAnimation(autoreverses: true))
```

### Requirements
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/develop/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/develop/CODE_OF_CONDUCT.md).
