### PR TITLE
Feature/resize labels based on number of lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to this project will be documented in this file
 ### Next version
 
 #### 🙌 New
-* [**340**](https://github.com/Juanpe/SkeletonView/pull/340): Fixed incorrect padding, and incorrect multiline layer frame calculation - [@yzhao198](https://github.com/yzhao198)
 * [**339**](https://github.com/Juanpe/SkeletonView/pull/339): Add `hiddenWhenSkeletonIsActive` property - [@mohn93](https://github.com/mohn93)
 * [**341**](https://github.com/Juanpe/SkeletonView/pull/341): Support autoreverses in gradient animations - [@Juanpe](https://github.com/Juanpe)
+* [**344**](https://github.com/Juanpe/SkeletonView/pull/344): Resize labels based on number of lines - [@Juanpe](https://github.com/Juanpe)
 
+#### 🩹 Bug fixes
+* [**340**](https://github.com/Juanpe/SkeletonView/pull/340): Fixed incorrect padding, and incorrect multiline layer frame calculation - [@yzhao198](https://github.com/yzhao198)
+* 
 ## 📦 [1.10.0](https://github.com/Juanpe/SkeletonView/releases/tag/1.10.0)
 
 #### 🙌 New

--- a/Example/TableView/Base.lproj/Main.storyboard
+++ b/Example/TableView/Base.lproj/Main.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Va7-1y-Tel">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Va7-1y-Tel">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -25,7 +26,7 @@
                                             <constraint firstAttribute="height" constant="78" id="gF5-G1-lKI"/>
                                         </constraints>
                                         <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. </string>
-                                        <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                        <color key="textColor" systemColor="labelColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                         <userDefinedRuntimeAttributes>
@@ -49,31 +50,38 @@
                                             <userDefinedRuntimeAttribute type="boolean" keyPath="isSkeletonable" value="YES"/>
                                         </userDefinedRuntimeAttributes>
                                     </imageView>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ifX-3x-oCb">
-                                        <rect key="frame" x="165" y="44.666666666666671" width="125" height="44"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CJW-A4-Fb8">
+                                        <rect key="frame" x="166" y="27" width="166" height="12"/>
+                                        <color key="backgroundColor" red="0.92156862750000001" green="0.16862745100000001" blue="0.54901960780000003" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="125" id="MuV-52-GiO"/>
-                                            <constraint firstAttribute="height" constant="44" id="vIU-os-12z"/>
+                                            <constraint firstAttribute="height" relation="lessThanOrEqual" constant="80" id="XAA-g8-NVH"/>
                                         </constraints>
-                                        <state key="normal" title="Button">
-                                            <color key="titleColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </state>
+                                        <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="boolean" keyPath="isSkeletonable" value="YES"/>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="linesCornerRadius">
+                                                <integer key="value" value="5"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="skeletonLineSpacing">
+                                                <real key="value" value="8"/>
+                                            </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
-                                    </button>
+                                    </label>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstItem="ifX-3x-oCb" firstAttribute="centerY" secondItem="nMj-pU-5wJ" secondAttribute="centerY" id="8sl-4R-4in"/>
+                                    <constraint firstItem="CJW-A4-Fb8" firstAttribute="leading" secondItem="nMj-pU-5wJ" secondAttribute="trailing" constant="28" id="Drg-cD-6E8"/>
                                     <constraint firstItem="e9V-mk-xH0" firstAttribute="leading" secondItem="F9K-jU-100" secondAttribute="leading" constant="45" id="HvQ-HY-zYU"/>
                                     <constraint firstItem="e9V-mk-xH0" firstAttribute="centerX" secondItem="F9K-jU-100" secondAttribute="centerX" constant="1" id="KcB-tG-NXa"/>
-                                    <constraint firstItem="ifX-3x-oCb" firstAttribute="leading" secondItem="nMj-pU-5wJ" secondAttribute="trailing" constant="27" id="LQC-s6-w43"/>
                                     <constraint firstAttribute="height" constant="243" id="MIj-xq-gr1"/>
                                     <constraint firstItem="nMj-pU-5wJ" firstAttribute="leading" secondItem="F9K-jU-100" secondAttribute="leading" constant="45" id="TK6-Ws-2xY"/>
                                     <constraint firstItem="e9V-mk-xH0" firstAttribute="top" secondItem="F9K-jU-100" secondAttribute="top" constant="142" id="Wcx-nZ-1lR"/>
                                     <constraint firstAttribute="trailing" secondItem="e9V-mk-xH0" secondAttribute="trailing" constant="43" id="XbU-Og-rht"/>
+                                    <constraint firstItem="CJW-A4-Fb8" firstAttribute="top" secondItem="F9K-jU-100" secondAttribute="top" constant="27" id="ceh-gB-7Et"/>
                                     <constraint firstItem="nMj-pU-5wJ" firstAttribute="top" secondItem="F9K-jU-100" secondAttribute="top" constant="20" id="hQL-cr-MaN"/>
+                                    <constraint firstAttribute="trailing" secondItem="CJW-A4-Fb8" secondAttribute="trailing" constant="43" id="nfT-a5-z36"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="isSkeletonable" value="YES"/>
@@ -91,7 +99,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="avatar" translatesAutoresizingMaskIntoConstraints="NO" id="oiE-tt-nc2">
-                                                    <rect key="frame" x="15" y="18" width="82" height="82"/>
+                                                    <rect key="frame" x="16" y="18" width="82" height="82"/>
                                                     <color key="backgroundColor" red="0.56078431370000004" green="0.59607843140000005" blue="0.7843137255" alpha="0.90709546230000004" colorSpace="calibratedRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="82" id="4j0-PU-CmN"/>
@@ -101,10 +109,11 @@
                                                         <userDefinedRuntimeAttribute type="boolean" keyPath="isSkeletonable" value="YES"/>
                                                     </userDefinedRuntimeAttributes>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VhU-1t-AaI" userLabel="Label">
-                                                    <rect key="frame" x="118" y="29" width="237" height="18"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VhU-1t-AaI" userLabel="Label">
+                                                    <rect key="frame" x="119" y="29" width="235" height="20"/>
+                                                    <color key="backgroundColor" red="0.92156862750000001" green="0.16862745100000001" blue="0.54901960780000003" alpha="1" colorSpace="calibratedRGB"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="height" relation="lessThanOrEqual" constant="71" id="HRL-cI-ieC"/>
+                                                        <constraint firstAttribute="height" constant="20" id="HRL-cI-ieC"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     <nil key="textColor"/>
@@ -198,7 +207,7 @@
                                             <action selector="btnChangeColorTouchUpInside:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cB8-Ik-LIJ"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tdu-YQ-saq">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tdu-YQ-saq">
                                         <rect key="frame" x="263" y="69" width="94" height="30"/>
                                         <state key="normal" title="Hide skeleton"/>
                                         <connections>
@@ -218,7 +227,7 @@
                                         </connections>
                                     </stepper>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="l4N-LL-ZrJ" firstAttribute="leading" secondItem="mrw-PM-jJJ" secondAttribute="trailing" constant="8" id="5iU-dO-qVc"/>
                                     <constraint firstItem="mrw-PM-jJJ" firstAttribute="centerY" secondItem="l4N-LL-ZrJ" secondAttribute="centerY" id="9OM-mx-4Jo"/>
@@ -243,7 +252,8 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="F9K-jU-100" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="1es-nY-bd3"/>
                             <constraint firstItem="F9K-jU-100" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="A3E-iv-1qp"/>
@@ -256,7 +266,6 @@
                             <constraint firstItem="UCB-SP-lQk" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="o6z-Dj-ppC"/>
                             <constraint firstItem="XgY-1a-UGc" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="vnZ-9k-MfI"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="boolean" keyPath="isSkeletonable" value="YES"/>
                         </userDefinedRuntimeAttributes>
@@ -285,8 +294,8 @@
                     <view key="view" contentMode="scaleToFill" id="Jwx-gI-Qod">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="Ao1-hk-zrH"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="Item" id="iKp-9S-aib"/>
                 </viewController>
@@ -316,5 +325,11 @@
     </scenes>
     <resources>
         <image name="avatar" width="215" height="211"/>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Example/TableView/ViewController.swift
+++ b/Example/TableView/ViewController.swift
@@ -52,11 +52,11 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         tableview.isSkeletonable = true
         transitionDurationStepper.value = 0.25
-        view.showAnimatedSkeleton()
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        view.showAnimatedSkeleton()
     }
 
     @IBAction func changeAnimated(_ sender: Any) {
@@ -180,7 +180,7 @@ extension ViewController: SkeletonTableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "CellIdentifier", for: indexPath) as! Cell
-        cell.label1.text = "cell => \(indexPath.row)"
+        cell.label1.text = "cell -> \(indexPath.row)"
         return cell
     }
 }
@@ -193,7 +193,7 @@ extension ViewController: SkeletonTableViewDelegate {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let header = tableView
             .dequeueReusableHeaderFooterView(withIdentifier: "HeaderIdentifier") as! HeaderFooterSection
-        header.titleLabel.text = "header => \(section)"
+        header.titleLabel.text = "header -> \(section)"
         return header
     }
 
@@ -204,7 +204,7 @@ extension ViewController: SkeletonTableViewDelegate {
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         let footer = tableView
             .dequeueReusableHeaderFooterView(withIdentifier: "FooterIdentifier") as! HeaderFooterSection
-        footer.titleLabel.text = "footer => \(section)"
+        footer.titleLabel.text = "footer -> \(section)"
         return footer
     }
 }

--- a/SkeletonView.xcodeproj/project.pbxproj
+++ b/SkeletonView.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		17DD0E1D207FB32100C56334 /* ContainsMultilineText.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5307E3A1FB123C100EE67C5 /* ContainsMultilineText.swift */; };
 		17DD0E1E207FB32100C56334 /* PrepareForSkeletonProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56B94451FAE20AF0095662F /* PrepareForSkeletonProtocol.swift */; };
 		17DD0E1F207FB32100C56334 /* RecursiveProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5307E311FB0F42F00EE67C5 /* RecursiveProtocol.swift */; };
+		1E291F3E2540655D0018D602 /* UIView+Autolayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E291F3D2540655D0018D602 /* UIView+Autolayout.swift */; };
+		1E291F3F2540655D0018D602 /* UIView+Autolayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E291F3D2540655D0018D602 /* UIView+Autolayout.swift */; };
 		1E6C67A2230E76CC0019D87B /* SkeletonTransitionStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4CE587C22EEE65200333067 /* SkeletonTransitionStyle.swift */; };
 		1E6C67A3230E76CE0019D87B /* UIView+Transitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4CE587B22EEE63100333067 /* UIView+Transitions.swift */; };
 		1EE42E1F23FF25CC00BF665A /* ProcessInfo+XCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EE42E1E23FF25CC00BF665A /* ProcessInfo+XCTest.swift */; };
@@ -161,6 +163,7 @@
 		17DD0E00207FB27400C56334 /* SkeletonView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SkeletonView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		17DD0E1A207FB2C200C56334 /* SkeletonView-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "SkeletonView-tvOS.plist"; sourceTree = "<group>"; };
 		17DD0E1B207FB2C200C56334 /* SkeletonView-iOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "SkeletonView-iOS.plist"; sourceTree = "<group>"; };
+		1E291F3D2540655D0018D602 /* UIView+Autolayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Autolayout.swift"; sourceTree = "<group>"; };
 		1EE42E1E23FF25CC00BF665A /* ProcessInfo+XCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProcessInfo+XCTest.swift"; sourceTree = "<group>"; };
 		42ABD06D210B548200BEEFF4 /* SkeletonViewExampleUICollectionView.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SkeletonViewExampleUICollectionView.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		42ABD070210B54E100BEEFF4 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -443,6 +446,7 @@
 				F5307E2D1FB0E5E400EE67C5 /* UIView+Frame.swift */,
 				F5804771230ECD0000066D02 /* UIView+IBInspectable.swift */,
 				F587FB85202CEC95002DB5FE /* UIView+UIApplicationDelegate.swift */,
+				1E291F3D2540655D0018D602 /* UIView+Autolayout.swift */,
 				5600784323FD293D00669AD6 /* UITableView+VisibleSections.swift */,
 				1EE42E1E23FF25CC00BF665A /* ProcessInfo+XCTest.swift */,
 			);
@@ -726,6 +730,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				872D5A5721C177E20037D763 /* UIView+Extension.swift in Sources */,
+				1E291F3F2540655D0018D602 /* UIView+Autolayout.swift in Sources */,
 				17DD0E1F207FB32100C56334 /* RecursiveProtocol.swift in Sources */,
 				872D5A5D21C24EDD0037D763 /* UILabel+Multiline.swift in Sources */,
 				17DD0E1E207FB32100C56334 /* PrepareForSkeletonProtocol.swift in Sources */,
@@ -786,6 +791,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E4CE588B22EEF70D00333067 /* UIView+Transitions.swift in Sources */,
+				1E291F3E2540655D0018D602 /* UIView+Autolayout.swift in Sources */,
 				872D5A5621C177E20037D763 /* UIView+Extension.swift in Sources */,
 				872D5A5C21C24EDD0037D763 /* UILabel+Multiline.swift in Sources */,
 				F54CF5E42024CEB000330B0D /* UIView+CollectionSkeleton.swift in Sources */,

--- a/Sources/Extensions/CALayer+Extensions.swift
+++ b/Sources/Extensions/CALayer+Extensions.swift
@@ -30,7 +30,7 @@ extension CAGradientLayer {
 
 struct SkeletonMultilinesLayerConfig {
 	var lines: Int
-	var lineHeight: CGFloat?
+	var lineHeight: CGFloat
 	var type: SkeletonType
 	var lastLineFillPercent: Int
 	var multilineCornerRadius: Int
@@ -56,8 +56,8 @@ extension CALayer {
     }
     
 	func addMultilinesLayers(for config: SkeletonMultilinesLayerConfig) {
-        let numberOfSublayers = config.lines == 1 ? 1 : calculateNumLines(for: config)
-        var height = config.lineHeight ?? SkeletonAppearance.default.multilineHeight
+        let numberOfSublayers = config.lines > 0 ? config.lines : calculateNumLines(for: config)
+        var height = config.lineHeight
         
         if numberOfSublayers == 1 && SkeletonAppearance.default.renderSingleLineAsView {
             height = bounds.height
@@ -88,7 +88,7 @@ extension CALayer {
         let lastLineFillPercent = config.lastLineFillPercent
         let paddingInsets = config.calculatedPaddingInsets
         let multilineSpacing = config.multilineSpacing
-        var height = config.lineHeight ?? SkeletonAppearance.default.multilineHeight
+        var height = config.lineHeight
         
         if numberOfSublayers == 1 && SkeletonAppearance.default.renderSingleLineAsView {
             height = bounds.height
@@ -113,26 +113,29 @@ extension CALayer {
     }
 
     func updateLayerFrame(for index: Int, size: CGSize, multilineSpacing: CGFloat, paddingInsets: UIEdgeInsets, isRTL: Bool) {
-        let spaceRequiredForEachLine = SkeletonAppearance.default.multilineHeight + multilineSpacing
+        let spaceRequiredForEachLine = size.height + multilineSpacing
         let newFrame = CGRect(x: paddingInsets.left,
                               y: CGFloat(index) * spaceRequiredForEachLine + paddingInsets.top,
                               width: size.width,
-                              height: size.height - paddingInsets.bottom - paddingInsets.top)
+                              height: size.height)
         
         frame = flipRectForRTLIfNeeded(newFrame, isRTL: isRTL)
     }
-
-	private func calculateNumLines(for config: SkeletonMultilinesLayerConfig) -> Int {
-		let requiredSpaceForEachLine = (config.lineHeight ?? SkeletonAppearance.default.multilineHeight) + config.multilineSpacing
-		var numberOfSublayers = Int(round(CGFloat(bounds.height - config.paddingInsets.top - config.paddingInsets.bottom) / CGFloat(requiredSpaceForEachLine)))
+    
+    private func calculateNumLines(for config: SkeletonMultilinesLayerConfig) -> Int {
+        let definedNumberOfLines = config.lines
+        let requiredSpaceForEachLine = config.lineHeight + config.multilineSpacing
+        let calculatedNumberOfLines = Int(round(CGFloat(bounds.height - config.paddingInsets.top - config.paddingInsets.bottom) / CGFloat(requiredSpaceForEachLine)))
         
-        if config.lines != 0, config.lines <= numberOfSublayers {
-            numberOfSublayers = config.lines
-        } else {
+        guard calculatedNumberOfLines > 0 else {
             return 1
         }
         
-        return numberOfSublayers
+        if definedNumberOfLines > 0, definedNumberOfLines <= calculatedNumberOfLines {
+            return definedNumberOfLines
+        }
+        
+        return calculatedNumberOfLines
     }
     
     private func flipRectForRTLIfNeeded(_ rect: CGRect, isRTL: Bool) -> CGRect {

--- a/Sources/Extensions/CALayer+Extensions.swift
+++ b/Sources/Extensions/CALayer+Extensions.swift
@@ -125,7 +125,13 @@ extension CALayer {
 	private func calculateNumLines(for config: SkeletonMultilinesLayerConfig) -> Int {
 		let requiredSpaceForEachLine = (config.lineHeight ?? SkeletonAppearance.default.multilineHeight) + config.multilineSpacing
 		var numberOfSublayers = Int(round(CGFloat(bounds.height - config.paddingInsets.top - config.paddingInsets.bottom) / CGFloat(requiredSpaceForEachLine)))
-		if config.lines != 0, config.lines <= numberOfSublayers { numberOfSublayers = config.lines }
+        
+        if config.lines != 0, config.lines <= numberOfSublayers {
+            numberOfSublayers = config.lines
+        } else {
+            return 1
+        }
+        
         return numberOfSublayers
     }
     

--- a/Sources/Extensions/UIView+Autolayout.swift
+++ b/Sources/Extensions/UIView+Autolayout.swift
@@ -1,0 +1,25 @@
+// Copyright © 2020 SkeletonView. All rights reserved.
+
+import UIKit
+
+// MARK: Frame
+extension UIView {
+    var widthConstraints: [NSLayoutConstraint] {
+        nonContentSizeLayoutConstraints.filter { $0.firstAttribute == NSLayoutConstraint.Attribute.width }
+    }
+    
+    var heightConstraints: [NSLayoutConstraint] {
+        nonContentSizeLayoutConstraints.filter { $0.firstAttribute == NSLayoutConstraint.Attribute.height }
+    }
+    
+    @discardableResult
+    func setHeight(equalToConstant constant: CGFloat) -> NSLayoutConstraint {
+        let heightConstraint = heightAnchor.constraint(equalToConstant: constant)
+        NSLayoutConstraint.activate([heightConstraint])
+        return heightConstraint
+    }
+    
+    var nonContentSizeLayoutConstraints: [NSLayoutConstraint] {
+        constraints.filter({ "\(type(of: $0))" != "NSContentSizeLayoutConstraint" })
+    }
+}

--- a/Sources/Extensions/UIView+Frame.swift
+++ b/Sources/Extensions/UIView+Frame.swift
@@ -10,32 +10,38 @@ import UIKit
 
 // MARK: Frame
 extension UIView {
-    var maxBoundsEstimated: CGRect {
+    var definedMaxBounds: CGRect {
         if let parentStackView = (superview as? UIStackView) {
             var origin: CGPoint = .zero
             switch parentStackView.alignment {
             case .trailing:
-                origin.x = maxWidthEstimated
+                origin.x = definedMaxWidth
             default:
                 break
             }
-            return CGRect(origin: origin, size: maxSizeEstimated)
+            return CGRect(origin: origin, size: definedMaxSize)
         }
-        return CGRect(origin: .zero, size: maxSizeEstimated)
+        return CGRect(origin: .zero, size: definedMaxSize)
     }
     
-    var maxSizeEstimated: CGSize {
-        return CGSize(width: maxWidthEstimated, height: maxHeightEstimated)
+    var definedMaxSize: CGSize {
+        CGSize(width: definedMaxWidth, height: definedMaxHeight)
     }
     
-    var maxWidthEstimated: CGFloat {
-        let constraintsWidth = nonContentSizeLayoutConstraints.filter({ $0.firstAttribute == NSLayoutConstraint.Attribute.width })
-        return max(between: frame.size.width, andContantsOf: constraintsWidth)
+    var definedMaxWidth: CGFloat {
+        max(between: frame.size.width, andContantsOf: widthConstraints)
     }
     
-    var maxHeightEstimated: CGFloat {
-        let constraintsHeight = nonContentSizeLayoutConstraints.filter({ $0.firstAttribute == NSLayoutConstraint.Attribute.height })
-        return max(between: frame.size.height, andContantsOf: constraintsHeight)
+    var definedMaxHeight: CGFloat {
+        max(between: frame.size.height, andContantsOf: heightConstraints)
+    }
+    
+    var isRTL: Bool {
+        if #available(iOS 10.0, *), #available(tvOS 10.0, *) {
+            return effectiveUserInterfaceLayoutDirection == .rightToLeft
+        } else {
+            return false
+        }
     }
     
     private func max(between value: CGFloat, andContantsOf constraints: [NSLayoutConstraint]) -> CGFloat {
@@ -45,17 +51,5 @@ extension UIView {
             return tempMax
         })
         return max
-    }
-    
-    var nonContentSizeLayoutConstraints: [NSLayoutConstraint] {
-        return constraints.filter({ "\(type(of: $0))" != "NSContentSizeLayoutConstraint" })
-    }
-    
-    var isRTL: Bool {
-        if #available(iOS 10.0, *), #available(tvOS 10.0, *) {
-            return effectiveUserInterfaceLayoutDirection == .rightToLeft
-        } else {
-            return false
-        }
     }
 }

--- a/Sources/Helpers/PrepareForSkeletonProtocol.swift
+++ b/Sources/Helpers/PrepareForSkeletonProtocol.swift
@@ -18,10 +18,38 @@ extension UIView {
 }
 
 extension UILabel {
+    var desiredHeightBasedOnNumberOfLines: CGFloat {
+        let lineHeight = multilineTextFont?.lineHeight ?? SkeletonAppearance.default.multilineHeight
+        let spaceNeededForEachLine = lineHeight * CGFloat(numberOfLines)
+        let spaceNeededForSpaces = skeletonLineSpacing * CGFloat(numberOfLines - 1)
+        let padding = paddingInsets.top + paddingInsets.bottom
+        
+        return spaceNeededForEachLine + spaceNeededForSpaces + padding
+    }
+    
+    func updateHeightConstraintsIfNeeded() {
+        guard numberOfLines > 1 else { return }
+        
+        let desiredHeight = desiredHeightBasedOnNumberOfLines
+        if desiredHeight > definedMaxHeight {
+            backupHeightConstraints = heightConstraints
+            NSLayoutConstraint.deactivate(heightConstraints)
+            setHeight(equalToConstant: desiredHeight)
+        }
+    }
+    
+    func restoreBackupHeightConstraints() {
+        guard !backupHeightConstraints.isEmpty else { return }
+        NSLayoutConstraint.deactivate(heightConstraints)
+        NSLayoutConstraint.activate(backupHeightConstraints)
+        backupHeightConstraints.removeAll()
+    }
+    
     override func prepareViewForSkeleton() {
         backgroundColor = .clear
         resignFirstResponder()
         startTransition { [weak self] in
+            self?.updateHeightConstraintsIfNeeded()
             self?.textColor = .clear
         }
     }

--- a/Sources/Multilines/ContainsMultilineText.swift
+++ b/Sources/Multilines/ContainsMultilineText.swift
@@ -7,6 +7,7 @@ enum MultilineAssociatedKeys {
     static var multilineCornerRadius = "multilineCornerRadius"
     static var multilineSpacing = "multilineSpacing"
     static var paddingInsets = "paddingInsets"
+    static var backupHeightConstraints = "backupHeightConstraints"
 }
 
 protocol ContainsMultilineText {
@@ -16,8 +17,4 @@ protocol ContainsMultilineText {
     var multilineCornerRadius: Int { get }
     var multilineSpacing: CGFloat { get }
     var paddingInsets: UIEdgeInsets { get }
-}
-
-extension ContainsMultilineText {
-    var numLines: Int { return 0 }
 }

--- a/Sources/Multilines/UILabel+Multiline.swift
+++ b/Sources/Multilines/UILabel+Multiline.swift
@@ -55,4 +55,9 @@ extension UILabel: ContainsMultilineText {
         get { return ao_get(pkey: &MultilineAssociatedKeys.paddingInsets) as? UIEdgeInsets ?? .zero }
         set { ao_set(newValue, pkey: &MultilineAssociatedKeys.paddingInsets) }
     }
+    
+    var backupHeightConstraints: [NSLayoutConstraint] {
+        get { return ao_get(pkey: &MultilineAssociatedKeys.backupHeightConstraints) as? [NSLayoutConstraint] ?? [] }
+        set { ao_set(newValue, pkey: &MultilineAssociatedKeys.backupHeightConstraints) }
+    }
 }

--- a/Sources/Multilines/UITextView+Multiline.swift
+++ b/Sources/Multilines/UITextView+Multiline.swift
@@ -29,8 +29,12 @@ public extension UITextView {
 
 extension UITextView: ContainsMultilineText {
 	var multilineTextFont: UIFont? {
-		return font
-	}
+        font
+    }
+    
+    var numLines: Int {
+        -1
+    }
 	
     var lastLineFillingPercent: Int {
         get {

--- a/Sources/Recoverable/Recoverable.swift
+++ b/Sources/Recoverable/Recoverable.swift
@@ -54,6 +54,8 @@ extension UILabel {
         startTransition { [weak self] in
             guard let storedLabelState = self?.labelState else { return }
             
+            self?.restoreBackupHeightConstraints()
+            
             if self?.textColor == .clear || forced {
                 self?.textColor = storedLabelState.textColor
             }

--- a/Sources/SkeletonLayer.swift
+++ b/Sources/SkeletonLayer.swift
@@ -49,7 +49,7 @@ struct SkeletonLayer {
         self.holder = holder
         self.maskLayer = type.layer
         self.maskLayer.anchorPoint = .zero
-        self.maskLayer.bounds = holder.maxBoundsEstimated
+        self.maskLayer.bounds = holder.definedMaxBounds
         self.maskLayer.cornerRadius = CGFloat(holder.skeletonCornerRadius)
         addTextLinesIfNeeded()
         self.maskLayer.tint(withColors: colors)
@@ -61,7 +61,7 @@ struct SkeletonLayer {
     }
 
     func layoutIfNeeded() {
-        if let bounds = holder?.maxBoundsEstimated {
+        if let bounds = holder?.definedMaxBounds {
             maskLayer.bounds = bounds
         }
         updateLinesIfNeeded()
@@ -83,9 +83,9 @@ struct SkeletonLayer {
     /// If there is more than one line, or custom preferences have been set for a single line, draw custom layers
     func addTextLinesIfNeeded() {
         guard let textView = holderAsTextView else { return }
-        
+        let lineHeight = textView.multilineTextFont?.lineHeight ?? SkeletonAppearance.default.multilineHeight
         let config = SkeletonMultilinesLayerConfig(lines: textView.numLines,
-                                                   lineHeight: textView.multilineTextFont?.lineHeight,
+                                                   lineHeight: lineHeight,
                                                    type: type,
                                                    lastLineFillPercent: textView.lastLineFillingPercent,
                                                    multilineCornerRadius: textView.multilineCornerRadius,
@@ -98,8 +98,9 @@ struct SkeletonLayer {
     
     func updateLinesIfNeeded() {
         guard let textView = holderAsTextView else { return }
+        let lineHeight = textView.multilineTextFont?.lineHeight ?? SkeletonAppearance.default.multilineHeight
         let config = SkeletonMultilinesLayerConfig(lines: textView.numLines,
-                                                   lineHeight: textView.multilineTextFont?.lineHeight,
+                                                   lineHeight: lineHeight,
                                                    type: type,
                                                    lastLineFillPercent: textView.lastLineFillingPercent,
                                                    multilineCornerRadius: textView.multilineCornerRadius,
@@ -112,7 +113,7 @@ struct SkeletonLayer {
     
     var holderAsTextView: ContainsMultilineText? {
         guard let textView = holder as? ContainsMultilineText,
-            (textView.numLines == 0 || textView.numLines > 1 || textView.numLines == 1 && !SkeletonAppearance.default.renderSingleLineAsView) else {
+            (textView.numLines == -1 || textView.numLines == 0 || textView.numLines > 1 || textView.numLines == 1 && !SkeletonAppearance.default.renderSingleLineAsView) else {
                 return nil
         }
         return textView


### PR DESCRIPTION
### Summary

This PR adds a new feature. Now, text nodes calculated the desired height for the defined number of lines. If the desired height is less than the current height, the library updates the constraints to modify the height and restore when the skeleton hides.

### Requirements
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/develop/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/develop/CODE_OF_CONDUCT.md).
