### PR TITLE
Fixed: UITextField placeholder text is visible while skeleton is showing

### DIFF
--- a/Example/TableView/Base.lproj/Main.storyboard
+++ b/Example/TableView/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Va7-1y-Tel">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Va7-1y-Tel">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -128,14 +128,25 @@
                                                         </userDefinedRuntimeAttribute>
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="placeholder" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="dha-bH-Ipf">
+                                                    <rect key="frame" x="119" y="57" width="235" height="34"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isSkeletonable" value="YES"/>
+                                                    </userDefinedRuntimeAttributes>
+                                                </textField>
                                             </subviews>
                                             <constraints>
+                                                <constraint firstItem="dha-bH-Ipf" firstAttribute="top" secondItem="VhU-1t-AaI" secondAttribute="bottom" constant="8" symbolic="YES" id="1Ek-1L-ZVs"/>
                                                 <constraint firstItem="oiE-tt-nc2" firstAttribute="leading" secondItem="7IN-F3-Mr6" secondAttribute="leadingMargin" id="1be-ak-AH1"/>
                                                 <constraint firstAttribute="bottom" secondItem="oiE-tt-nc2" secondAttribute="bottom" constant="20" id="CKt-oA-eBI"/>
                                                 <constraint firstItem="oiE-tt-nc2" firstAttribute="top" secondItem="7IN-F3-Mr6" secondAttribute="topMargin" constant="7" id="EKn-ST-LDX"/>
                                                 <constraint firstAttribute="trailingMargin" secondItem="VhU-1t-AaI" secondAttribute="trailing" constant="5" id="I7C-Bq-mfK"/>
                                                 <constraint firstItem="VhU-1t-AaI" firstAttribute="leading" secondItem="oiE-tt-nc2" secondAttribute="trailing" constant="21" id="Ojr-Kz-1k6"/>
                                                 <constraint firstItem="VhU-1t-AaI" firstAttribute="top" secondItem="7IN-F3-Mr6" secondAttribute="topMargin" constant="18" id="ZW6-JY-S4c"/>
+                                                <constraint firstItem="dha-bH-Ipf" firstAttribute="trailing" secondItem="VhU-1t-AaI" secondAttribute="trailing" id="baX-Nw-8sB"/>
+                                                <constraint firstItem="dha-bH-Ipf" firstAttribute="leading" secondItem="VhU-1t-AaI" secondAttribute="leading" id="kzA-mV-IDt"/>
                                             </constraints>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="boolean" keyPath="isSkeletonable" value="YES"/>

--- a/Sources/Helpers/PrepareForSkeletonProtocol.swift
+++ b/Sources/Helpers/PrepareForSkeletonProtocol.swift
@@ -69,6 +69,7 @@ extension UITextField {
     override func prepareViewForSkeleton() {
         backgroundColor = .clear
         resignFirstResponder()
+
         startTransition { [weak self] in
             self?.textColor = .clear
             self?.placeholder = nil

--- a/Sources/Helpers/PrepareForSkeletonProtocol.swift
+++ b/Sources/Helpers/PrepareForSkeletonProtocol.swift
@@ -65,6 +65,17 @@ extension UITextView {
     }
 }
 
+extension UITextField {
+    override func prepareViewForSkeleton() {
+        backgroundColor = .clear
+        resignFirstResponder()
+        startTransition { [weak self] in
+            self?.textColor = .clear
+            self?.placeholder = nil
+        }
+    }
+}
+
 extension UIImageView {
     override func prepareViewForSkeleton() {
         backgroundColor = .clear

--- a/Sources/Recoverable/Recoverable.swift
+++ b/Sources/Recoverable/Recoverable.swift
@@ -86,6 +86,33 @@ extension UITextView {
     }
 }
 
+extension UITextField {
+    var textState: RecoverableTextFieldState? {
+        get { return ao_get(pkey: &ViewAssociatedKeys.labelViewState) as? RecoverableTextFieldState }
+        set { ao_setOptional(newValue, pkey: &ViewAssociatedKeys.labelViewState) }
+    }
+
+    override func saveViewState() {
+        super.saveViewState()
+        textState = RecoverableTextFieldState(view: self)
+    }
+
+    override func recoverViewState(forced: Bool) {
+        super.recoverViewState(forced: forced)
+        startTransition { [weak self] in
+            guard let storedLabelState = self?.textState else { return }
+
+            if self?.textColor == .clear || forced {
+                self?.textColor = storedLabelState.textColor
+            }
+
+            if self?.placeholder == nil || forced {
+                self?.placeholder = storedLabelState.placeholder
+            }
+        }
+    }
+}
+
 extension UIImageView {
     var imageState: RecoverableImageViewState? {
         get { return ao_get(pkey: &ViewAssociatedKeys.imageViewState) as? RecoverableImageViewState }

--- a/Sources/Recoverable/RecoverableViewState.swift
+++ b/Sources/Recoverable/RecoverableViewState.swift
@@ -34,6 +34,16 @@ struct RecoverableTextViewState {
     }
 }
 
+struct RecoverableTextFieldState {
+    var textColor: UIColor?
+    var placeholder: String?
+
+    init(view: UITextField) {
+        self.textColor = view.textColor
+        self.placeholder = view.placeholder
+    }
+}
+
 struct RecoverableImageViewState {
     var image: UIImage?
     


### PR DESCRIPTION
…ing #345

Setting placeholder to nil on prepareViewForSkeleton() method
Created RecoverableTextFieldState, which has textColor and placeholder properties, 
Added UITextField extension in Recoverable.swift
Setting the values back to UITextField properties on recoverViewStage method with 'forced' parameter is true

### Summary

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/develop/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/develop/CODE_OF_CONDUCT.md).
