### PR TITLE
Fixed: SkeletonView respecting Font's height, rather than the `UIView…

### DIFF
--- a/Sources/Helpers/PrepareForSkeletonProtocol.swift
+++ b/Sources/Helpers/PrepareForSkeletonProtocol.swift
@@ -19,7 +19,7 @@ extension UIView {
 
 extension UILabel {
     var desiredHeightBasedOnNumberOfLines: CGFloat {
-        let lineHeight = multilineTextFont?.lineHeight ?? SkeletonAppearance.default.multilineHeight
+        let lineHeight = constraintHeight ?? SkeletonAppearance.default.multilineHeight
         let spaceNeededForEachLine = lineHeight * CGFloat(numberOfLines)
         let spaceNeededForSpaces = skeletonLineSpacing * CGFloat(numberOfLines - 1)
         let padding = paddingInsets.top + paddingInsets.bottom

--- a/Sources/Multilines/ContainsMultilineText.swift
+++ b/Sources/Multilines/ContainsMultilineText.swift
@@ -11,7 +11,7 @@ enum MultilineAssociatedKeys {
 }
 
 protocol ContainsMultilineText {
-	var multilineTextFont: UIFont? { get }
+    var constraintHeight: CGFloat? { get }
     var numLines: Int { get }
     var lastLineFillingPercent: Int { get }
     var multilineCornerRadius: Int { get }

--- a/Sources/Multilines/UILabel+Multiline.swift
+++ b/Sources/Multilines/UILabel+Multiline.swift
@@ -28,10 +28,10 @@ public extension UILabel {
 }
 
 extension UILabel: ContainsMultilineText {
-	var multilineTextFont: UIFont? {
-		return font
-	}
-	
+    var constraintHeight: CGFloat? {
+        backupHeightConstraints.first?.constant
+    }
+
     var numLines: Int {
         return numberOfLines
     }

--- a/Sources/Multilines/UITextView+Multiline.swift
+++ b/Sources/Multilines/UITextView+Multiline.swift
@@ -28,8 +28,8 @@ public extension UITextView {
 }
 
 extension UITextView: ContainsMultilineText {
-	var multilineTextFont: UIFont? {
-        font
+    var constraintHeight: CGFloat? {
+        heightConstraints.first?.constant
     }
     
     var numLines: Int {

--- a/Sources/SkeletonLayer.swift
+++ b/Sources/SkeletonLayer.swift
@@ -83,7 +83,7 @@ struct SkeletonLayer {
     /// If there is more than one line, or custom preferences have been set for a single line, draw custom layers
     func addTextLinesIfNeeded() {
         guard let textView = holderAsTextView else { return }
-        let lineHeight = textView.multilineTextFont?.lineHeight ?? SkeletonAppearance.default.multilineHeight
+        let lineHeight = textView.constraintHeight ?? SkeletonAppearance.default.multilineHeight
         let config = SkeletonMultilinesLayerConfig(lines: textView.numLines,
                                                    lineHeight: lineHeight,
                                                    type: type,
@@ -98,7 +98,7 @@ struct SkeletonLayer {
     
     func updateLinesIfNeeded() {
         guard let textView = holderAsTextView else { return }
-        let lineHeight = textView.multilineTextFont?.lineHeight ?? SkeletonAppearance.default.multilineHeight
+        let lineHeight = textView.constraintHeight ?? SkeletonAppearance.default.multilineHeight
         let config = SkeletonMultilinesLayerConfig(lines: textView.numLines,
                                                    lineHeight: lineHeight,
                                                    type: type,


### PR DESCRIPTION
…` actual height #353

### Summary

Fixed #353
Using Label height from the HeightConstraint if there is any HeightConstraint set instead of the Label Font line height
if no HeightConstraint set, will be using SkeletonAppearance.default.multilineHeight as it was before

### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/develop/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/develop/CODE_OF_CONDUCT.md).
