### PR TITLE
restore `isUserInteractionEnabled` value

### DIFF
--- a/Sources/Collections/CollectionSkeletonProtocol.swift
+++ b/Sources/Collections/CollectionSkeletonProtocol.swift
@@ -29,6 +29,14 @@ extension CollectionSkeleton where Self: UIScrollView {
     var estimatedNumberOfRows: Int { return 0 }
     func addDummyDataSource() {}
     func removeDummyDataSource(reloadAfter: Bool) {}
-    func disableUserInteraction() { isUserInteractionEnabled = false; isScrollEnabled = false }
-    func enableUserInteraction() { isUserInteractionEnabled = true; isScrollEnabled = true }
+
+    func disableUserInteraction() {
+        isUserInteractionEnabled = false
+        isScrollEnabled = false
+    }
+    
+    func enableUserInteraction() {
+        isUserInteractionEnabled = true
+        isScrollEnabled = true
+    }
 }

--- a/Sources/Extensions/UIColor+Skeleton.swift
+++ b/Sources/Extensions/UIColor+Skeleton.swift
@@ -50,7 +50,7 @@ extension UIColor {
 }
 
 public extension UIColor {
-    // swiftlint:disable
+    // swiftlint:disable operator_usage_whitespace
     static var greenSea     = UIColor(0x16a085)
     static var turquoise    = UIColor(0x1abc9c)
     static var emerald      = UIColor(0x2ecc71)
@@ -72,7 +72,7 @@ public extension UIColor {
     static var pomegranate  = UIColor(0xc0392b)
     static var silver       = UIColor(0xbdc3c7)
     static var asbestos     = UIColor(0x7f8c8d)
-    // swiftlint:enable
+    // swiftlint:enable operator_usage_whitespace
     
     static var skeletonDefault: UIColor {
         if #available(iOS 13, tvOS 13, *) {

--- a/Sources/Helpers/PrepareForSkeletonProtocol.swift
+++ b/Sources/Helpers/PrepareForSkeletonProtocol.swift
@@ -10,9 +10,9 @@ import UIKit
 
 extension UIView {
     @objc func prepareViewForSkeleton() {
+        isUserInteractionEnabled = false
         startTransition { [weak self] in
             self?.backgroundColor = .clear
-            self?.isUserInteractionEnabled = false
         }
     }
 }
@@ -49,6 +49,7 @@ extension UILabel {
     
     override func prepareViewForSkeleton() {
         backgroundColor = .clear
+        isUserInteractionEnabled = false
         resignFirstResponder()
         startTransition { [weak self] in
             self?.updateHeightConstraintsIfNeeded()
@@ -60,6 +61,7 @@ extension UILabel {
 extension UITextView {
     override func prepareViewForSkeleton() {
         backgroundColor = .clear
+        isUserInteractionEnabled = false
         resignFirstResponder()
         startTransition { [weak self] in
             self?.textColor = .clear
@@ -82,6 +84,7 @@ extension UITextField {
 extension UIImageView {
     override func prepareViewForSkeleton() {
         backgroundColor = .clear
+        isUserInteractionEnabled = false
         startTransition { [weak self] in
             self?.image = nil
         }
@@ -91,6 +94,7 @@ extension UIImageView {
 extension UIButton {
     override func prepareViewForSkeleton() {
         backgroundColor = .clear
+        isUserInteractionEnabled = false
         startTransition { [weak self] in
             self?.setTitle(nil, for: .normal)
         }

--- a/Sources/SkeletonView.swift
+++ b/Sources/SkeletonView.swift
@@ -136,7 +136,7 @@ extension UIView {
     private func showSkeletonIfNotActive(skeletonConfig config: SkeletonConfig) {
         guard !isSkeletonActive else { return }
         saveViewState()
-        isUserInteractionEnabled = false
+
         prepareViewForSkeleton()
         addSkeletonLayer(skeletonConfig: config)
     }
@@ -190,7 +190,6 @@ extension UIView {
             isHidden = false
         }
         currentSkeletonConfig?.transition = transition
-        isUserInteractionEnabled = true
         removeDummyDataSourceIfNeeded(reloadAfter: reload)
         subviewsSkeletonables.recursiveSearch(leafBlock: {
             recoverViewState(forced: false)


### PR DESCRIPTION
### Summary

The goal of this pull request is to restore the `isUserInteractionEnabled` when the skeleton is gone.

### Requirements
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
