### PR TITLE
Deprecation warning fix for AssociatedObjects protocol from `class`  to `AnyObject`

### DIFF
--- a/Sources/Helpers/AssociationPolicy.swift
+++ b/Sources/Helpers/AssociationPolicy.swift
@@ -17,7 +17,7 @@ enum AssociationPolicy: UInt {
     }
 }
 
-protocol AssociatedObjects: class { }
+protocol AssociatedObjects: AnyObject { }
 
 // transparent wrappers
 extension AssociatedObjects {


### PR DESCRIPTION
### Summary

I was updating my iOS app to be able to run on Xcode 12.5 (beta) and noticed that Apple is now flagging the use of `class` inherited protocols as `deprecated` in favor of inheriting from `AnyObject`. In my iOS app, we flag warnings as errors so now our app won't compile. I wanted to be able to pitch in and help modernize the code so I went ahead and fixed this deprecation here. 

<img width="853" alt="Screen Shot 2021-02-08 at 12 32 59 PM" src="https://user-images.githubusercontent.com/1315688/107281077-0de30400-6a0e-11eb-8ead-0a189f1fa98a.png">

After a little bit of research, I came across this forum Swift.org [post](https://forums.swift.org/t/class-only-protocols-class-vs-anyobject/11507/4) which seems to point to the discussion where this deprecation discussion started.

### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
