### PR TITLE
feat: add workaround to simulate the content of labels contained in a stack view.

### DIFF
--- a/Sources/Extensions/UIView+Extension.swift
+++ b/Sources/Extensions/UIView+Extension.swift
@@ -49,4 +49,8 @@ extension UIView {
         get { return ao_get(pkey: &ViewAssociatedKeys.isSkeletonAnimated) as? Bool ?? false }
         set { ao_set(newValue, pkey: &ViewAssociatedKeys.isSkeletonAnimated) }
     }
+    
+    var isSuperviewAStackView: Bool {
+        superview is UIStackView
+    }
 }

--- a/Sources/Helpers/PrepareForSkeletonProtocol.swift
+++ b/Sources/Helpers/PrepareForSkeletonProtocol.swift
@@ -28,7 +28,12 @@ extension UILabel {
     }
     
     func updateHeightConstraintsIfNeeded() {
-        guard numberOfLines > 1 else { return }
+        guard numberOfLines > 1 || numberOfLines == 0 else { return }
+        
+        // Workaround to simulate content when the label is contained in a `UIStackView`.
+        if isSuperviewAStackView, bounds.height == 0 {
+            text = "This is a placeholder text to simulate content because it's contained in a stack view in order to prevent that the content size will be zero."
+        }
         
         let desiredHeight = desiredHeightBasedOnNumberOfLines
         if desiredHeight > definedMaxHeight {


### PR DESCRIPTION
### Summary

When a label is contained in a `UIStackView` and the content is nil, the bounds is zero and the stack view content size is zero as well. The idea is to set a placeholder text to simulate content to allow the library to calculate effectively the desired size of the label.

