### PR TITLE
UnSwizzle methods

### DIFF
--- a/Example/TableView/Base.lproj/Main.storyboard
+++ b/Example/TableView/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Va7-1y-Tel">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Va7-1y-Tel">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -155,6 +155,7 @@
                                         <connections>
                                             <outlet property="avatar" destination="oiE-tt-nc2" id="Dkh-R5-Qhu"/>
                                             <outlet property="label1" destination="VhU-1t-AaI" id="kUW-HV-KrD"/>
+                                            <outlet property="textField" destination="dha-bH-Ipf" id="OHI-6P-tuU"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>

--- a/Example/TableView/Cell.swift
+++ b/Example/TableView/Cell.swift
@@ -9,11 +9,25 @@
 import UIKit
 
 class Cell: UITableViewCell {
-    
+
     @IBOutlet weak var avatar: UIImageView!
     @IBOutlet weak var label1: UILabel!
-    
+    @IBOutlet weak var textField: UITextField!
+
     override func awakeFromNib() {
         super.awakeFromNib()
+        setUpInputAccessoryView()
+    }
+
+    func setUpInputAccessoryView() {
+        let bar = UIToolbar()
+        let reset = UIBarButtonItem(title: "InputAccessoryView", style: .plain, target: self, action: #selector(resetTapped))
+        bar.items = [reset]
+        bar.sizeToFit()
+        textField.inputAccessoryView = bar
+    }
+
+    @objc func resetTapped() {
+
     }
 }

--- a/Sources/Helpers/Swizzling.swift
+++ b/Sources/Helpers/Swizzling.swift
@@ -4,12 +4,19 @@ import Foundation
 
 extension DispatchQueue {
     private static var _onceTracker = [String]()
-    
+
     class func once(token: String, block: () -> Void) {
         objc_sync_enter(self); defer { objc_sync_exit(self) }
         guard !_onceTracker.contains(token) else { return }
-        
+
         _onceTracker.append(token)
+        block()
+    }
+
+    class func removeOnce(token: String, block: () -> Void) {
+        objc_sync_enter(self); defer { objc_sync_exit(self) }
+        guard let index = _onceTracker.firstIndex(of: token) else { return }
+        _onceTracker.remove(at: index)
         block()
     }
 }
@@ -18,7 +25,7 @@ func swizzle(selector originalSelector: Selector, with swizzledSelector: Selecto
     guard let originalMethod = class_getInstanceMethod(inClass, originalSelector),
         let swizzledMethod = class_getInstanceMethod(usingClass, swizzledSelector)
         else { return }
-    
+
     if class_addMethod(inClass, swizzledSelector, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod)) {
         class_replaceMethod(inClass, originalSelector, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod))
     } else {

--- a/Sources/SkeletonView.swift
+++ b/Sources/SkeletonView.swift
@@ -190,6 +190,8 @@ extension UIView {
             isHidden = false
         }
         currentSkeletonConfig?.transition = transition
+        unSwizzleLayoutSubviews()
+        unSwizzleTraitCollectionDidChange()
         removeDummyDataSourceIfNeeded(reloadAfter: reload)
         subviewsSkeletonables.recursiveSearch(leafBlock: {
             recoverViewState(forced: false)
@@ -233,11 +235,33 @@ extension UIView {
         }
     }
 
+    private func unSwizzleLayoutSubviews() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+            DispatchQueue.removeOnce(token: "UIView.SkeletonView.swizzleLayoutSubviews") {
+                swizzle(selector: #selector(UIView.skeletonLayoutSubviews),
+                        with: #selector(UIView.layoutSubviews),
+                        inClass: UIView.self,
+                        usingClass: UIView.self)
+            }
+        }
+    }
+
     private func swizzleTraitCollectionDidChange() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
             DispatchQueue.once(token: "UIView.SkeletonView.swizzleTraitCollectionDidChange") {
                 swizzle(selector: #selector(UIView.traitCollectionDidChange(_:)),
                         with: #selector(UIView.skeletonTraitCollectionDidChange(_:)),
+                        inClass: UIView.self,
+                        usingClass: UIView.self)
+            }
+        }
+    }
+
+    private func unSwizzleTraitCollectionDidChange() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+            DispatchQueue.removeOnce(token: "UIView.SkeletonView.swizzleTraitCollectionDidChange") {
+                swizzle(selector: #selector(UIView.skeletonTraitCollectionDidChange(_:)),
+                        with: #selector(UIView.traitCollectionDidChange(_:)),
                         inClass: UIView.self,
                         usingClass: UIView.self)
             }


### PR DESCRIPTION
### Summary

Describe the goal of this PR. Mention any related Issue numbers.
https://github.com/Juanpe/SkeletonView/issues/373
https://github.com/Juanpe/SkeletonView/issues/358
https://github.com/Juanpe/SkeletonView/issues/331
https://github.com/Juanpe/SkeletonView/issues/202
https://github.com/Juanpe/SkeletonView/issues/352

This PR adds methods to `unSwizzleLayoutSubviews` & `unSwizzleTraitCollectionDidChange` in order not to interfere with other controller methods when skeletonView is hidden.
These methods are being called once if swizzle is enabled at `recursiveHideSkeleton`.

Unswizzle is simple re-run with reverted selectors to stop swizzle.

My PL also includes a toolbar in textField to test whether an infinite loop exists when changing  floating to normal keyboard (in iPad).

Let me know what you think.


### Requirements (place an `x` in each of the `[ ]`)
* [X] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
