### PR TITLE
[BUG] Fix crashing on NaN value

### DIFF
--- a/Sources/Extensions/CALayer+Extensions.swift
+++ b/Sources/Extensions/CALayer+Extensions.swift
@@ -125,8 +125,12 @@ extension CALayer {
     private func calculateNumLines(for config: SkeletonMultilinesLayerConfig) -> Int {
         let definedNumberOfLines = config.lines
         let requiredSpaceForEachLine = config.lineHeight + config.multilineSpacing
-        let calculatedNumberOfLines = Int(round(CGFloat(bounds.height - config.paddingInsets.top - config.paddingInsets.bottom) / CGFloat(requiredSpaceForEachLine)))
-        
+        let neededLines = round(CGFloat(bounds.height - config.paddingInsets.top - config.paddingInsets.bottom) / CGFloat(requiredSpaceForEachLine))
+        guard neededLines.isNormal else {
+            return 0
+        }
+
+        let calculatedNumberOfLines = Int(neededLines)
         guard calculatedNumberOfLines > 0 else {
             return 1
         }


### PR DESCRIPTION
### Summary

Describe the goal of this PR. Mention any related Issue numbers.

This PR fixes a crash seen when the result of `CGFloat(bounds.height - config.paddingInsets.top - config.paddingInsets.bottom) / CGFloat(requiredSpaceForEachLine)` is `0`

Applying `round` to `0` results in `NaN` which crashes the runtime when converting to `Int`

[https://www.dropbox.com/s/u9id3amj27370bw/Screen%20Shot%202021-04-09%20at%203.04.05%20PM.png?dl=0](https://www.dropbox.com/s/u9id3amj27370bw/Screen%20Shot%202021-04-09%20at%203.04.05%20PM.png?dl=0)

Steps to reproduce:
- Skeletonize a text field or label
- Set elements height to 0
- call `.showAnimatedGradientSkeleton()` [or I am assuming any of the .show methods]

In our app we dynamically resize a text view depending if there is text within, it might be notable that the text view is embedded in a stackView, but I assume the crash would happen either way if the view size is 0.

### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
