### PR TITLE
fix UITableViewAlertForLayoutOutsideViewHierarchy warning

### DIFF
--- a/Sources/SubviewsSkeletonables.swift
+++ b/Sources/SubviewsSkeletonables.swift
@@ -14,7 +14,11 @@ extension UIView {
 
 extension UITableView {
     override var subviewsToSkeleton: [UIView] {
-        visibleCells + visibleSectionHeaders + visibleSectionFooters
+		// on `UIViewController'S onViewDidLoad`, the window is still nil.
+		// Some developer trying to call `view.showAnimatedSkeleton()`
+		// when the request or data is loading which sometimes happens before the ViewDidAppear
+		guard window != nil else { return [] }
+		return visibleCells + visibleSectionHeaders + visibleSectionFooters
     }
 }
 


### PR DESCRIPTION
### Summary

close #383 

avoid having this warning
> [TableView] Warning once only: UITableView was told to layout its visible cells and other contents without being in the view hierarchy (the table view or one of its superviews has not been added to a window). This may cause bugs by forcing views inside the table view to load and perform layout without accurate information (e.g. table view bounds, trait collection, layout margins, safe area insets, etc), and will also cause unnecessary performance overhead due to extra layout passes. Make a symbolic breakpoint at UITableViewAlertForLayoutOutsideViewHierarchy to catch this in the debugger and see what caused this to occur, so you can avoid this action altogether if possible, or defer it until the table view has been added to a window.

* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
