### PR TITLE
update the placeholder to use an empty space

### DIFF
--- a/Sources/Helpers/PrepareForSkeletonProtocol.swift
+++ b/Sources/Helpers/PrepareForSkeletonProtocol.swift
@@ -32,7 +32,8 @@ extension UILabel {
         
         // Workaround to simulate content when the label is contained in a `UIStackView`.
         if isSuperviewAStackView, bounds.height == 0 {
-            text = "This is a placeholder text to simulate content because it's contained in a stack view in order to prevent that the content size will be zero."
+            // This is a placeholder text to simulate content because it's contained in a stack view in order to prevent that the content size will be zero.
+            text = " "
         }
         
         let desiredHeight = desiredHeightBasedOnNumberOfLines


### PR DESCRIPTION
### Summary

in `iOS12`, this placeholder is still appearing before the skeleton view appears and will disappear immediately. (but it's still visible and recognizable) 

close #388

<img width="464" alt="Screen Shot 2021-05-07 at 11 28 13 am" src="https://user-images.githubusercontent.com/717992/117385490-94818180-af28-11eb-8505-287b2e508b79.png">

This also prevents having a bigger skeleton view than what is actually needed.

### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
