### PR TITLE
use the right delegate method for footers

### DIFF
--- a/Sources/Collections/CollectionViews/UICollectionView+CollectionSkeleton.swift
+++ b/Sources/Collections/CollectionViews/UICollectionView+CollectionSkeleton.swift
@@ -7,11 +7,10 @@
 //
 
 import UIKit
-
+ 
 extension UICollectionView: CollectionSkeleton {
     var estimatedNumberOfRows: Int {
         guard let flowlayout = collectionViewLayout as? UICollectionViewFlowLayout else { return 0 }
-        return Int(ceil(frame.height / flowlayout.itemSize.height))
         switch flowlayout.scrollDirection {
         case .vertical:
             return Int(ceil(frame.height / flowlayout.itemSize.height))

--- a/Sources/Collections/SkeletonCollectionDelegate.swift
+++ b/Sources/Collections/SkeletonCollectionDelegate.swift
@@ -25,7 +25,7 @@ extension SkeletonCollectionDelegate: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        headerOrFooterView(tableView, for: originalTableViewDelegate?.collectionSkeletonView(tableView, identifierForHeaderInSection: section))
+        headerOrFooterView(tableView, for: originalTableViewDelegate?.collectionSkeletonView(tableView, identifierForFooterInSection: section))
     }
 
     func tableView(_ tableView: UITableView, didEndDisplayingHeaderView view: UIView, forSection section: Int) {


### PR DESCRIPTION
### Summary

The collection delegate was using the header method to get the identifier of the footers. Now, it uses the right method. 

As we can see in the screenshot, the delegate method is called to get the footer identifier.
![Screenshot 2021-05-11 at 19 11 08](https://user-images.githubusercontent.com/1409041/117857173-c67a4700-b28c-11eb-8f07-81b35e2e6640.png)

Close #393 

### Requirements
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
