### PR TITLE
Add SkeletonCollectionDataSource.automaticNumberOfRows Constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ func collectionSkeletonView(_ skeletonView: UITableView, numberOfRowsInSection s
 // It calculates how many cells need to populate whole tableview
 ```
 
-If you return SkeletonCollectionDataSource.automaticNumberOfRows in the above method, it acts like the default behavior (i.e. it calculates how many cells needed to populate the whole tableview).
+> 📣 **IMPORTANT!** 
+>
+> If you return `SkeletonCollectionDataSource.automaticNumberOfRows` in the above method, it acts like the default behavior (i.e. it calculates how many cells needed to populate the whole tableview).
 
 There is only one method you need to implement to let Skeleton know the cell identifier. This method doesn't have default implementation:
  ``` swift

--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ func collectionSkeletonView(_ skeletonView: UITableView, numberOfRowsInSection s
 // It calculates how many cells need to populate whole tableview
 ```
 
+If you return SkeletonCollectionDataSource.automaticNumberOfRows in the above method, it acts like the default behavior (i.e. it calculates how many cells needed to populate the whole tableview).
+
 There is only one method you need to implement to let Skeleton know the cell identifier. This method doesn't have default implementation:
  ``` swift
  func collectionSkeletonView(_ skeletonView: UITableView, cellIdentifierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier

--- a/Sources/Collections/CollectionViews/SkeletonCollectionViewProtocols.swift
+++ b/Sources/Collections/CollectionViews/SkeletonCollectionViewProtocols.swift
@@ -17,7 +17,7 @@ public protocol SkeletonCollectionViewDataSource: UICollectionViewDataSource {
 
 public extension SkeletonCollectionViewDataSource {
     func collectionSkeletonView(_ skeletonView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return skeletonView.estimatedNumberOfRows
+        return Self.automaticNumberOfRows
     }
     
     func collectionSkeletonView(_ skeletonView: UICollectionView,

--- a/Sources/Collections/SkeletonCollectionDataSource.swift
+++ b/Sources/Collections/SkeletonCollectionDataSource.swift
@@ -11,6 +11,8 @@ import UIKit
 public typealias ReusableCellIdentifier = String
 
 class SkeletonCollectionDataSource: NSObject {
+    static let automaticNumberOfRows = -1
+
     weak var originalTableViewDataSource: SkeletonTableViewDataSource?
     weak var originalCollectionViewDataSource: SkeletonCollectionViewDataSource?
     var rowHeight: CGFloat = 0.0

--- a/Sources/Collections/SkeletonCollectionDataSource.swift
+++ b/Sources/Collections/SkeletonCollectionDataSource.swift
@@ -34,7 +34,17 @@ extension SkeletonCollectionDataSource: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        originalTableViewDataSource?.collectionSkeletonView(tableView, numberOfRowsInSection: section) ?? 0
+        guard let originalTableViewDataSource = originalTableViewDataSource else {
+            return 0
+        }
+
+        let numberOfRows = originalTableViewDataSource.collectionSkeletonView(tableView, numberOfRowsInSection: section)
+
+        if numberOfRows == Self.automaticNumberOfRows {
+            return tableView.estimatedNumberOfRows
+        } else {
+            return numberOfRows
+        }
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -52,7 +62,17 @@ extension SkeletonCollectionDataSource: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        originalCollectionViewDataSource?.collectionSkeletonView(collectionView, numberOfItemsInSection: section) ?? 0
+        guard let originalCollectionViewDataSource = originalCollectionViewDataSource else {
+            return 0
+        }
+
+        let numberOfItems = originalCollectionViewDataSource.collectionSkeletonView(collectionView, numberOfItemsInSection: section)
+
+        if numberOfItems == Self.automaticNumberOfRows {
+            return collectionView.estimatedNumberOfRows
+        } else {
+            return numberOfItems
+        }
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
+++ b/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
@@ -16,7 +16,7 @@ public protocol SkeletonTableViewDataSource: UITableViewDataSource {
 
 public extension SkeletonTableViewDataSource {
     func collectionSkeletonView(_ skeletonView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return skeletonView.estimatedNumberOfRows
+        return Self.automaticNumberOfRows
     }
     
     func numSections(in collectionSkeletonView: UITableView) -> Int { return 1 }


### PR DESCRIPTION
### Summary

Add a new `SkeletonCollectionDataSource.automaticNumberOfRows` constant that can be returned from `tableView(_:numberOfRowsInSection:)` or `collectionView(_:numberOfItemsInSection:)` to allow for the default behavior (i.e. `estimatedNumberOfRows` to be returned).  This will help with abstractions around `SkeletonTableViewDataSource` and `SkeletonCollectionViewDataSource` to be more customizable.

Closes #400 

### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
