### PR TITLE
Fix TableViewCell skeleton not being removed & automaticNumberOfRows reference

### DIFF
--- a/Sources/Collections/CollectionViews/SkeletonCollectionViewProtocols.swift
+++ b/Sources/Collections/CollectionViews/SkeletonCollectionViewProtocols.swift
@@ -17,7 +17,7 @@ public protocol SkeletonCollectionViewDataSource: UICollectionViewDataSource {
 
 public extension SkeletonCollectionViewDataSource {
     func collectionSkeletonView(_ skeletonView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return Self.automaticNumberOfRows
+        return SkeletonCollectionDataSource.automaticNumberOfRows
     }
     
     func collectionSkeletonView(_ skeletonView: UICollectionView,

--- a/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
+++ b/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
@@ -16,7 +16,7 @@ public protocol SkeletonTableViewDataSource: UITableViewDataSource {
 
 public extension SkeletonTableViewDataSource {
     func collectionSkeletonView(_ skeletonView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return Self.automaticNumberOfRows
+        return SkeletonCollectionDataSource.automaticNumberOfRows
     }
     
     func numSections(in collectionSkeletonView: UITableView) -> Int { return 1 }

--- a/Sources/SubviewsSkeletonables.swift
+++ b/Sources/SubviewsSkeletonables.swift
@@ -18,7 +18,7 @@ extension UITableView {
 		// Some developer trying to call `view.showAnimatedSkeleton()`
 		// when the request or data is loading which sometimes happens before the ViewDidAppear
 		guard window != nil else { return [] }
-		return visibleCells + visibleSectionHeaders + visibleSectionFooters
+        return subviews
     }
 }
 


### PR DESCRIPTION
### Summary

- For UITableView the skeleton is added/removed to `visibleCells`, `visibleSectionHeaders` & `visibleSectionFooters`, however when `hideSkeleton` is called with `reloadDataAfter: true` this can leave some cells with the skeleton still active because `visibleCells` may not contain the same number of cells as when `showSkeleton` was called (i.e. when the estimatedRowHeight is significantly less than the actual row height).  Changed to add/remove skeleton to all TableView subviews. Fixes #399.

- Fix `automaticNumberOfRows` reference error from PR #401.

### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
