### PR TITLE
fix bug remove constraints wrongly

### DIFF
--- a/Sources/Extensions/UIView+Autolayout.swift
+++ b/Sources/Extensions/UIView+Autolayout.swift
@@ -12,9 +12,17 @@ extension UIView {
         nonContentSizeLayoutConstraints.filter { $0.firstAttribute == NSLayoutConstraint.Attribute.height }
     }
     
+    var skeletonHeightConstraints: [NSLayoutConstraint] {
+        nonContentSizeLayoutConstraints.filter {
+            $0.firstAttribute == NSLayoutConstraint.Attribute.height
+                && $0.identifier?.contains("SkeletonView.Constraint.Height") ?? false
+        }
+    }
+    
     @discardableResult
     func setHeight(equalToConstant constant: CGFloat) -> NSLayoutConstraint {
         let heightConstraint = heightAnchor.constraint(equalToConstant: constant)
+        heightConstraint.identifier = "SkeletonView.Constraint.Height.\(constant)"
         NSLayoutConstraint.activate([heightConstraint])
         return heightConstraint
     }

--- a/Sources/Helpers/PrepareForSkeletonProtocol.swift
+++ b/Sources/Helpers/PrepareForSkeletonProtocol.swift
@@ -48,10 +48,9 @@ extension UILabel {
     }
     
     func restoreBackupHeightConstraintsIfNeeded() {
+        NSLayoutConstraint.deactivate(skeletonHeightConstraints)
+        
         guard !backupHeightConstraints.isEmpty else { return }
-        heightConstraints.forEach {
-            removeConstraint($0)
-        }
         NSLayoutConstraint.activate(backupHeightConstraints)
         backupHeightConstraints.removeAll()
     }

--- a/Sources/Helpers/PrepareForSkeletonProtocol.swift
+++ b/Sources/Helpers/PrepareForSkeletonProtocol.swift
@@ -48,8 +48,6 @@ extension UILabel {
     }
     
     func restoreBackupHeightConstraintsIfNeeded() {
-        NSLayoutConstraint.deactivate(skeletonHeightConstraints)
-        
         guard !backupHeightConstraints.isEmpty else { return }
         NSLayoutConstraint.activate(backupHeightConstraints)
         backupHeightConstraints.removeAll()

--- a/Sources/Helpers/PrepareForSkeletonProtocol.swift
+++ b/Sources/Helpers/PrepareForSkeletonProtocol.swift
@@ -47,11 +47,11 @@ extension UILabel {
         }
     }
     
-    func restoreBackupHeightConstraints() {
+    func restoreBackupHeightConstraintsIfNeeded() {
+        guard !backupHeightConstraints.isEmpty else { return }
         heightConstraints.forEach {
             removeConstraint($0)
         }
-        guard !backupHeightConstraints.isEmpty else { return }
         NSLayoutConstraint.activate(backupHeightConstraints)
         backupHeightConstraints.removeAll()
     }

--- a/Sources/Recoverable/Recoverable.swift
+++ b/Sources/Recoverable/Recoverable.swift
@@ -59,7 +59,7 @@ extension UILabel {
         startTransition { [weak self] in
             guard let storedLabelState = self?.labelState else { return }
             
-            self?.restoreBackupHeightConstraints()
+            self?.restoreBackupHeightConstraintsIfNeeded()
             
             if self?.textColor == .clear || forced {
                 self?.textColor = storedLabelState.textColor

--- a/Sources/Recoverable/Recoverable.swift
+++ b/Sources/Recoverable/Recoverable.swift
@@ -57,12 +57,16 @@ extension UILabel {
     override func recoverViewState(forced: Bool) {
         super.recoverViewState(forced: forced)
         startTransition { [weak self] in
-            guard let storedLabelState = self?.labelState else { return }
+            guard let self = self,
+                  let storedLabelState = self.labelState else {
+                return
+            }
             
-            self?.restoreBackupHeightConstraintsIfNeeded()
+            NSLayoutConstraint.deactivate(self.skeletonHeightConstraints)
+            self.restoreBackupHeightConstraintsIfNeeded()
             
-            if self?.textColor == .clear || forced {
-                self?.textColor = storedLabelState.textColor
+            if self.textColor == .clear || forced {
+                self.textColor = storedLabelState.textColor
             }
         }
     }


### PR DESCRIPTION
### Summary

Fixes #405 

This PR fixes a bug related to the constraints that SkeletonView added to labels when the skeleton is active. The previous logic was:

#### When the labels are prepared for the skeleton:
1. Check the desired height for labels.
2. If needed, backup the current constraints and remove them.
3. Activate the calculated skeleton constraints.

#### When the skeleton disappears
1. Remove all the constraints related to the height.
2. If there are some constraints backed up, restore them.

The problem was step 1 when the skeleton disappears because we were always removing the height constraints, even if the library had added no constraints.

The solution is to add an identifier to constraints added by the library. Then, SkeletonView only removes the constraints added by the library. So, the logic now when the skeleton disappears is:

1. Remove all the constraints related to the height **added by the library**.
2. If there are some constraints backed up, restore them.

### Requirements
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
