### PR TITLE
Replace SkeletonCollectionDataSource.automaticNumberOfRows with UITableView.automaticNumberOfSkeletonRows and UICollectionView.automaticNumberOfSkeletonItems

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ func collectionSkeletonView(_ skeletonView: UITableView, numberOfRowsInSection s
 
 > 📣 **IMPORTANT!** 
 >
-> If you return `SkeletonCollectionDataSource.automaticNumberOfRows` in the above method, it acts like the default behavior (i.e. it calculates how many cells needed to populate the whole tableview).
+> If you return `UITableView.automaticNumberOfSkeletonRows` in the above method, it acts like the default behavior (i.e. it calculates how many cells needed to populate the whole tableview).
 
 There is only one method you need to implement to let Skeleton know the cell identifier. This method doesn't have default implementation:
  ``` swift

--- a/Sources/Collections/CollectionViews/SkeletonCollectionViewProtocols.swift
+++ b/Sources/Collections/CollectionViews/SkeletonCollectionViewProtocols.swift
@@ -17,7 +17,7 @@ public protocol SkeletonCollectionViewDataSource: UICollectionViewDataSource {
 
 public extension SkeletonCollectionViewDataSource {
     func collectionSkeletonView(_ skeletonView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return SkeletonCollectionDataSource.automaticNumberOfRows
+        return UICollectionView.automaticNumberOfSkeletonItems
     }
     
     func collectionSkeletonView(_ skeletonView: UICollectionView,

--- a/Sources/Collections/CollectionViews/UICollectionView+CollectionSkeleton.swift
+++ b/Sources/Collections/CollectionViews/UICollectionView+CollectionSkeleton.swift
@@ -9,6 +9,8 @@
 import UIKit
  
 extension UICollectionView: CollectionSkeleton {
+    public static let automaticNumberOfSkeletonItems = -1
+
     var estimatedNumberOfRows: Int {
         guard let flowlayout = collectionViewLayout as? UICollectionViewFlowLayout else { return 0 }
         switch flowlayout.scrollDirection {

--- a/Sources/Collections/SkeletonCollectionDataSource.swift
+++ b/Sources/Collections/SkeletonCollectionDataSource.swift
@@ -11,8 +11,6 @@ import UIKit
 public typealias ReusableCellIdentifier = String
 
 class SkeletonCollectionDataSource: NSObject {
-    static let automaticNumberOfRows = -1
-
     weak var originalTableViewDataSource: SkeletonTableViewDataSource?
     weak var originalCollectionViewDataSource: SkeletonCollectionViewDataSource?
     var rowHeight: CGFloat = 0.0
@@ -40,7 +38,7 @@ extension SkeletonCollectionDataSource: UITableViewDataSource {
 
         let numberOfRows = originalTableViewDataSource.collectionSkeletonView(tableView, numberOfRowsInSection: section)
 
-        if numberOfRows == Self.automaticNumberOfRows {
+        if numberOfRows == UITableView.automaticNumberOfSkeletonRows {
             return tableView.estimatedNumberOfRows
         } else {
             return numberOfRows
@@ -68,7 +66,7 @@ extension SkeletonCollectionDataSource: UICollectionViewDataSource {
 
         let numberOfItems = originalCollectionViewDataSource.collectionSkeletonView(collectionView, numberOfItemsInSection: section)
 
-        if numberOfItems == Self.automaticNumberOfRows {
+        if numberOfItems == UICollectionView.automaticNumberOfSkeletonItems {
             return collectionView.estimatedNumberOfRows
         } else {
             return numberOfItems

--- a/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
+++ b/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
@@ -16,7 +16,7 @@ public protocol SkeletonTableViewDataSource: UITableViewDataSource {
 
 public extension SkeletonTableViewDataSource {
     func collectionSkeletonView(_ skeletonView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return SkeletonCollectionDataSource.automaticNumberOfRows
+        return UITableView.automaticNumberOfSkeletonRows
     }
     
     func numSections(in collectionSkeletonView: UITableView) -> Int { return 1 }

--- a/Sources/Collections/TableViews/UITableView+CollectionSkeleton.swift
+++ b/Sources/Collections/TableViews/UITableView+CollectionSkeleton.swift
@@ -11,6 +11,8 @@ import UIKit
 public typealias ReusableHeaderFooterIdentifier = String
 
 extension UITableView: CollectionSkeleton {
+    public static let automaticNumberOfSkeletonRows = -1
+
     var estimatedNumberOfRows: Int {
         return Int(ceil(frame.height / rowHeight))
     }


### PR DESCRIPTION
### Summary

The previous implementation for this (Issue #400, Pull Request #401) was incorrect as `SkeletonCollectionDataSource` is not a public class.  Therefore, this fixes the issue by replacing `SkeletonCollectionDataSource.automaticNumberOfRows` with `UITableView.automaticNumberOfSkeletonRows` and `UICollectionView.automaticNumberOfSkeletonItems`.

Closes #408 

### Requirements
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
