### PR TITLE
Improved the algorithm that calculates the number of skeleton lines for UITextViews

### DIFF
--- a/Sources/Helpers/PrepareForSkeletonProtocol.swift
+++ b/Sources/Helpers/PrepareForSkeletonProtocol.swift
@@ -22,7 +22,6 @@ extension UIView {
 
 extension UILabel {
     var desiredHeightBasedOnNumberOfLines: CGFloat {
-        let lineHeight = constraintHeight ?? SkeletonAppearance.default.multilineHeight
         let spaceNeededForEachLine = lineHeight * CGFloat(numberOfLines)
         let spaceNeededForSpaces = skeletonLineSpacing * CGFloat(numberOfLines - 1)
         let padding = paddingInsets.top + paddingInsets.bottom

--- a/Sources/Multilines/ContainsMultilineText.swift
+++ b/Sources/Multilines/ContainsMultilineText.swift
@@ -11,8 +11,8 @@ enum MultilineAssociatedKeys {
 }
 
 protocol ContainsMultilineText {
-    var constraintHeight: CGFloat? { get }
-    var numLines: Int { get }
+    var lineHeight: CGFloat { get }
+    var numberOfLines: Int { get }
     var lastLineFillingPercent: Int { get }
     var multilineCornerRadius: Int { get }
     var multilineSpacing: CGFloat { get }

--- a/Sources/Multilines/UILabel+Multiline.swift
+++ b/Sources/Multilines/UILabel+Multiline.swift
@@ -27,15 +27,11 @@ public extension UILabel {
     }
 }
 
-extension UILabel: ContainsMultilineText {
-    var constraintHeight: CGFloat? {
-        backupHeightConstraints.first?.constant
+extension UILabel: ContainsMultilineText {    
+    var lineHeight: CGFloat {
+        backupHeightConstraints.first?.constant ?? SkeletonAppearance.default.multilineHeight
     }
-
-    var numLines: Int {
-        return numberOfLines
-    }
-
+    
     var lastLineFillingPercent: Int {
         get { return ao_get(pkey: &MultilineAssociatedKeys.lastLineFillingPercent) as? Int ?? SkeletonAppearance.default.multilineLastLineFillPercent }
         set { ao_set(newValue, pkey: &MultilineAssociatedKeys.lastLineFillingPercent) }

--- a/Sources/Multilines/UITextView+Multiline.swift
+++ b/Sources/Multilines/UITextView+Multiline.swift
@@ -28,11 +28,19 @@ public extension UITextView {
 }
 
 extension UITextView: ContainsMultilineText {
-    var constraintHeight: CGFloat? {
-        heightConstraints.first?.constant
+    var lineHeight: CGFloat {
+        if let fontLineHeight = font?.lineHeight {
+            if let heightConstraints = heightConstraints.first?.constant {
+                return (fontLineHeight > heightConstraints) ? heightConstraints : fontLineHeight
+            }
+            
+            return fontLineHeight
+        }
+        
+        return SkeletonAppearance.default.multilineHeight
     }
     
-    var numLines: Int {
+    var numberOfLines: Int {
         -1
     }
 	

--- a/Sources/SkeletonLayer.swift
+++ b/Sources/SkeletonLayer.swift
@@ -83,9 +83,8 @@ struct SkeletonLayer {
     /// If there is more than one line, or custom preferences have been set for a single line, draw custom layers
     func addTextLinesIfNeeded() {
         guard let textView = holderAsTextView else { return }
-        let lineHeight = textView.constraintHeight ?? SkeletonAppearance.default.multilineHeight
-        let config = SkeletonMultilinesLayerConfig(lines: textView.numLines,
-                                                   lineHeight: lineHeight,
+        let config = SkeletonMultilinesLayerConfig(lines: textView.numberOfLines,
+                                                   lineHeight: textView.lineHeight,
                                                    type: type,
                                                    lastLineFillPercent: textView.lastLineFillingPercent,
                                                    multilineCornerRadius: textView.multilineCornerRadius,
@@ -98,9 +97,8 @@ struct SkeletonLayer {
     
     func updateLinesIfNeeded() {
         guard let textView = holderAsTextView else { return }
-        let lineHeight = textView.constraintHeight ?? SkeletonAppearance.default.multilineHeight
-        let config = SkeletonMultilinesLayerConfig(lines: textView.numLines,
-                                                   lineHeight: lineHeight,
+        let config = SkeletonMultilinesLayerConfig(lines: textView.numberOfLines,
+                                                   lineHeight: textView.lineHeight,
                                                    type: type,
                                                    lastLineFillPercent: textView.lastLineFillingPercent,
                                                    multilineCornerRadius: textView.multilineCornerRadius,
@@ -113,7 +111,7 @@ struct SkeletonLayer {
     
     var holderAsTextView: ContainsMultilineText? {
         guard let textView = holder as? ContainsMultilineText,
-            (textView.numLines == -1 || textView.numLines == 0 || textView.numLines > 1 || textView.numLines == 1 && !SkeletonAppearance.default.renderSingleLineAsView) else {
+            (textView.numberOfLines == -1 || textView.numberOfLines == 0 || textView.numberOfLines > 1 || textView.numberOfLines == 1 && !SkeletonAppearance.default.renderSingleLineAsView) else {
                 return nil
         }
         return textView

--- a/Sources/SkeletonView.swift
+++ b/Sources/SkeletonView.swift
@@ -277,14 +277,22 @@ extension UIView {
             .setHolder(self)
             .build()
             else { return }
-
+        
         self.skeletonLayer = skeletonLayer
-        layer.insertSublayer(skeletonLayer,
-                             at: UInt32.max,
-                             transition: config.transition) { [weak self] in
-                                if config.animated {
-                                    self?.startSkeletonAnimation(config.animation)
-                                }
+        layer.insertSkeletonLayer(
+            skeletonLayer,
+            atIndex: UInt32.max,
+            transition: config.transition
+        ) { [weak self] in
+            guard let self = self else { return }
+            
+            /// Workaround to fix the problem when inserting a sublayer and
+            /// the content offset is modified by the system.
+            (self as? UITextView)?.setContentOffset(.zero, animated: false)
+            
+            if config.animated {
+                self.startSkeletonAnimation(config.animation)
+            }
         }
         status = .on
     }

--- a/Sources/Transitions/UIView+Transitions.swift
+++ b/Sources/Transitions/UIView+Transitions.swift
@@ -3,13 +3,13 @@
 import UIKit
 
 extension CALayer {
-    func insertSublayer(_ layer: SkeletonLayer, at idx: UInt32, transition: SkeletonTransitionStyle, completion: (() -> Void)? = nil) {
-        insertSublayer(layer.contentLayer, at: idx)
+    func insertSkeletonLayer(_ sublayer: SkeletonLayer, atIndex index: UInt32, transition: SkeletonTransitionStyle, completion: (() -> Void)? = nil) {
+        insertSublayer(sublayer.contentLayer, at: index)
         switch transition {
         case .none:
             completion?()
         case .crossDissolve(let duration):
-			layer.contentLayer.setOpacity(from: 0, to: 1, duration: duration, completion: completion)
+            sublayer.contentLayer.setOpacity(from: 0, to: 1, duration: duration, completion: completion)
         }
     }
 }


### PR DESCRIPTION
### Summary

The goal of this PR is to improve the algorithm that calculates the number of skeleton lines for `UITextView`s. Now, the library is using the same logic for `UILabel`s and `UITextView`s. The library took the height of the view to calculate the height of each skeleton line. But this is not valid for `UITextView`s, because they have a height defined from the beginning and it's higher than the height of the line. So now the library takes into account the font line height and the height of the view defined by the constraints to calculate the final height.

#### Before fix
![before_fix](https://user-images.githubusercontent.com/1409041/122894737-c0758c80-d347-11eb-90cd-7a74bb793516.png)

#### After fix
![after_fix](https://user-images.githubusercontent.com/1409041/122894733-bf445f80-d347-11eb-8860-bcb266b0a661.png)

### Requirements
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
