### PR TITLE
Delay the presentation of the skeletons

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,24 @@ By default, the user interaction is disabled for skeletonized items, but if you 
 view.isUserInteractionDisabledWhenSkeletonIsActive = false  // The view will be active when the skeleton will be active.
 ```
 
+**Delayed show skeleton**
+
+You can delay the showIf the views are updated quickly you canAn optional delay applied to the transition, like the transition duration.
+
+```swift
+func showSkeleton(usingColor: UIColor,
+                  animated: Bool,
+                  delay: TimeInterval,
+                  transition: SkeletonTransitionStyle)
+```
+
+```swift
+func showGradientSkeleton(usingGradient: SkeletonGradient,
+                          animated: Bool,
+                          delay: TimeInterval,
+                          transition: SkeletonTransitionStyle)
+```
+
 **Debug**
 
 To facilitate the debug tasks when something is not working fine. **`SkeletonView`** has some new tools.

--- a/Sources/Extensions/UIView+Extension.swift
+++ b/Sources/Extensions/UIView+Extension.swift
@@ -17,6 +17,7 @@ enum ViewAssociatedKeys {
     static var currentSkeletonConfig = "currentSkeletonConfig"
     static var skeletonCornerRadius = "skeletonCornerRadius"
     static var disabledWhenSkeletonIsActive = "disabledWhenSkeletonIsActive"
+    static var delayedShowSkeletonWorkItem = "delayedShowSkeletonWorkItem"
 }
 // codebeat:enable[TOO_MANY_IVARS]
 
@@ -53,5 +54,10 @@ extension UIView {
     
     var isSuperviewAStackView: Bool {
         superview is UIStackView
+    }
+    
+    var delayedShowSkeletonWorkItem: DispatchWorkItem? {
+        get { return ao_get(pkey: &ViewAssociatedKeys.delayedShowSkeletonWorkItem) as? DispatchWorkItem }
+        set { ao_setOptional(newValue, pkey: &ViewAssociatedKeys.delayedShowSkeletonWorkItem) }
     }
 }

--- a/Sources/SkeletonView.swift
+++ b/Sources/SkeletonView.swift
@@ -9,8 +9,27 @@ public extension UIView {
     ///   - color: The color of the skeleton. Defaults to `SkeletonAppearance.default.tintColor`.
     ///   - transition: The style of the transition when the skeleton appears. Defaults to `.crossDissolve(0.25)`.
     func showSkeleton(usingColor color: UIColor = SkeletonAppearance.default.tintColor, transition: SkeletonTransitionStyle = .crossDissolve(0.25)) {
+        delayedShowSkeletonWorkItem?.cancel()
         let config = SkeletonConfig(type: .solid, colors: [color], transition: transition)
         showSkeleton(skeletonConfig: config)
+    }
+    
+    /// Shows the skeleton using the view that calls this method as root view.
+    ///
+    /// - Parameters:
+    ///   - color: The color of the skeleton. Defaults to `SkeletonAppearance.default.tintColor`.
+    ///   - animated: If the skeleton is animated or not. Defaults to `true`.
+    ///   - delay: The amount of time (measured in seconds) to wait before show the skeleton.
+    ///   - transition: The style of the transition when the skeleton appears. Defaults to `.crossDissolve(0.25)`.
+    func showSkeleton(usingColor color: UIColor = SkeletonAppearance.default.tintColor, animated: Bool = true, delay: TimeInterval, transition: SkeletonTransitionStyle = .crossDissolve(0.25)) {
+        delayedShowSkeletonWorkItem?.cancel()
+        
+        delayedShowSkeletonWorkItem = DispatchWorkItem { [weak self] in
+            let config = SkeletonConfig(type: .solid, colors: [color], animated: animated, transition: transition)
+            self?.showSkeleton(skeletonConfig: config)
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: delayedShowSkeletonWorkItem!)
     }
     
     /// Shows the gradient skeleton without animation using the view that calls this method as root view.
@@ -19,8 +38,32 @@ public extension UIView {
     ///   - gradient: The gradient of the skeleton. Defaults to `SkeletonAppearance.default.gradient`.
     ///   - transition: The style of the transition when the skeleton appears. Defaults to `.crossDissolve(0.25)`.
     func showGradientSkeleton(usingGradient gradient: SkeletonGradient = SkeletonAppearance.default.gradient, transition: SkeletonTransitionStyle = .crossDissolve(0.25)) {
+        delayedShowSkeletonWorkItem?.cancel()
         let config = SkeletonConfig(type: .gradient, colors: gradient.colors, transition: transition)
         showSkeleton(skeletonConfig: config)
+    }
+    
+    /// Shows the gradient skeleton using the view that calls this method as root view.
+    ///
+    /// - Parameters:
+    ///   - gradient: The gradient of the skeleton. Defaults to `SkeletonAppearance.default.gradient`.
+    ///   - animated: If the skeleton is animated or not. Defaults to `true`.
+    ///   - delay: The amount of time (measured in seconds) to wait before show the skeleton.
+    ///   - transition: The style of the transition when the skeleton appears. Defaults to `.crossDissolve(0.25)`.
+    func showGradientSkeleton(
+        usingGradient gradient: SkeletonGradient = SkeletonAppearance.default.gradient,
+        animated: Bool = true,
+        delay: TimeInterval,
+        transition: SkeletonTransitionStyle = .crossDissolve(0.25)
+    ) {
+        delayedShowSkeletonWorkItem?.cancel()
+        
+        delayedShowSkeletonWorkItem = DispatchWorkItem { [weak self] in
+            let config = SkeletonConfig(type: .gradient, colors: gradient.colors, animated: animated, transition: transition)
+            self?.showSkeleton(skeletonConfig: config)
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: delayedShowSkeletonWorkItem!)
     }
     
     /// Shows the animated skeleton using the view that calls this method as root view.
@@ -32,6 +75,7 @@ public extension UIView {
     ///   - animation: The animation of the skeleton. Defaults to `nil`.
     ///   - transition: The style of the transition when the skeleton appears. Defaults to `.crossDissolve(0.25)`.
     func showAnimatedSkeleton(usingColor color: UIColor = SkeletonAppearance.default.tintColor, animation: SkeletonLayerAnimation? = nil, transition: SkeletonTransitionStyle = .crossDissolve(0.25)) {
+        delayedShowSkeletonWorkItem?.cancel()
         let config = SkeletonConfig(type: .solid, colors: [color], animated: true, animation: animation, transition: transition)
         showSkeleton(skeletonConfig: config)
     }
@@ -45,6 +89,7 @@ public extension UIView {
     ///   - animation: The animation of the skeleton. Defaults to `nil`.
     ///   - transition: The style of the transition when the skeleton appears. Defaults to `.crossDissolve(0.25)`.
     func showAnimatedGradientSkeleton(usingGradient gradient: SkeletonGradient = SkeletonAppearance.default.gradient, animation: SkeletonLayerAnimation? = nil, transition: SkeletonTransitionStyle = .crossDissolve(0.25)) {
+        delayedShowSkeletonWorkItem?.cancel()
         let config = SkeletonConfig(type: .gradient, colors: gradient.colors, animated: true, animation: animation, transition: transition)
         showSkeleton(skeletonConfig: config)
     }
@@ -75,6 +120,7 @@ public extension UIView {
     }
     
     func hideSkeleton(reloadDataAfter reload: Bool = true, transition: SkeletonTransitionStyle = .crossDissolve(0.25)) {
+        delayedShowSkeletonWorkItem?.cancel()
         flowDelegate?.willBeginHidingSkeletons(rootView: self)
         recursiveHideSkeleton(reloadDataAfter: reload, transition: transition, root: self)
     }


### PR DESCRIPTION
### Summary

Fixes #379 

> If using SkeletonView for views that are mostly updated quickly, the SkeletonView transition looks like a short flashing of the view.

The solution was to create two methods to delay the skeleton transition. So, now you can delay the presentation of the skeleton if the views update quickly.

```swift
func showSkeleton(usingColor: UIColor,
                  animated: Bool,
                  delay: TimeInterval,
                  transition: SkeletonTransitionStyle)
```

```swift
func showGradientSkeleton(usingGradient: SkeletonGradient,
                          animated: Bool,
                          delay: TimeInterval,
                          transition: SkeletonTransitionStyle)
```

### Requirements
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
