### PR TITLE
Feature - Configure Cell

### DIFF
--- a/Example/CollectionView/ViewController.swift
+++ b/Example/CollectionView/ViewController.swift
@@ -175,6 +175,12 @@ extension ViewController: SkeletonCollectionViewDataSource {
         return 10
     }
     
+    func collectionSkeletonView(_ skeletonView: UICollectionView, skeletonCellForItemAt indexPath: IndexPath) -> UICollectionViewCell? {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "CollectionViewCell", for: indexPath) as? CollectionViewCell
+        cell?.isSkeletonable = indexPath.row != 0
+        return cell
+    }
+    
     // MARK: - UICollectionViewDataSource
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/Example/TableView/ViewController.swift
+++ b/Example/TableView/ViewController.swift
@@ -183,6 +183,12 @@ extension ViewController: SkeletonTableViewDataSource {
         cell.label1.text = "cell -> \(indexPath.row)"
         return cell
     }
+    
+    func collectionSkeletonView(_ skeletonView: UITableView, skeletonCellForRowAt indexPath: IndexPath) -> UITableViewCell? {
+        let cell = skeletonView.dequeueReusableCell(withIdentifier: "CellIdentifier", for: indexPath) as? Cell
+        cell?.textField.isHidden = indexPath.row == 0
+        return cell
+    }
 }
 
 extension ViewController: SkeletonTableViewDelegate {

--- a/README.md
+++ b/README.md
@@ -169,19 +169,15 @@ If you want to show the skeleton in a ```UITableView```, you need to conform to 
 
 ``` swift
 public protocol SkeletonTableViewDataSource: UITableViewDataSource {
-    func numSections(in collectionSkeletonView: UITableView) -> Int
+    func numSections(in collectionSkeletonView: UITableView) -> Int // Default: 1
     func collectionSkeletonView(_ skeletonView: UITableView, numberOfRowsInSection section: Int) -> Int
     func collectionSkeletonView(_ skeletonView: UITableView, cellIdentifierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier
+    func collectionSkeletonView(_ skeletonView: UITableView, skeletonCellForRowAt indexPath: IndexPath) -> UITableViewCell? // Default: nil
 }
 ```
 As you can see, this protocol inherits from ```UITableViewDataSource```, so you can replace this protocol with the skeleton protocol.
 
-This protocol has a default implementation:
-
-``` swift
-func numSections(in collectionSkeletonView: UITableView) -> Int
-// Default: 1
-```
+This protocol has a default implementation for some methods. For example, the number of rows for each section is calculated in runtime:
 
 ``` swift
 func collectionSkeletonView(_ skeletonView: UITableView, numberOfRowsInSection section: Int) -> Int
@@ -195,14 +191,18 @@ func collectionSkeletonView(_ skeletonView: UITableView, numberOfRowsInSection s
 
 There is only one method you need to implement to let Skeleton know the cell identifier. This method doesn't have default implementation:
  ``` swift
- func collectionSkeletonView(_ skeletonView: UITableView, cellIdentifierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier
- ```
-
-**Example**
- ``` swift
  func collectionSkeletonView(_ skeletonView: UITableView, cellIdentifierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier {
     return "CellIdentifier"
 }
+ ```
+ 
+ By default, the library dequeues the cells from each indexPath, but you can also do this if you want to make some changes before the skeleton appears:
+ ``` swift
+ func collectionSkeletonView(_ skeletonView: UITableView, skeletonCellForRowAt indexPath: IndexPath) -> UITableViewCell? {
+     let cell = skeletonView.dequeueReusableCell(withIdentifier: "CellIdentifier", for: indexPath) as? Cell
+     cell?.textField.isHidden = indexPath.row == 0
+     return cell
+ }
  ```
  
 Besides, you can skeletonize both the headers and footers. You need to conform to `SkeletonTableViewDelegate` protocol.
@@ -232,10 +232,11 @@ For `UICollectionView`, you need to conform to `SkeletonCollectionViewDataSource
 
 ``` swift
 public protocol SkeletonCollectionViewDataSource: UICollectionViewDataSource {
-    func numSections(in collectionSkeletonView: UICollectionView) -> Int // default: 1
+    func numSections(in collectionSkeletonView: UICollectionView) -> Int  // default: 1
     func collectionSkeletonView(_ skeletonView: UICollectionView, numberOfItemsInSection section: Int) -> Int
     func collectionSkeletonView(_ skeletonView: UICollectionView, cellIdentifierForItemAt indexPath: IndexPath) -> ReusableCellIdentifier
     func collectionSkeletonView(_ skeletonView: UICollectionView, supplementaryViewIdentifierOfKind: String, at indexPath: IndexPath) -> ReusableCellIdentifier? // default: nil
+    func collectionSkeletonView(_ skeletonView: UICollectionView, skeletonCellForItemAt indexPath: IndexPath) -> UICollectionViewCell?  // default: nil
 }
 ```
 

--- a/Sources/Collections/CollectionViews/SkeletonCollectionViewProtocols.swift
+++ b/Sources/Collections/CollectionViews/SkeletonCollectionViewProtocols.swift
@@ -13,20 +13,25 @@ public protocol SkeletonCollectionViewDataSource: UICollectionViewDataSource {
     func collectionSkeletonView(_ skeletonView: UICollectionView, numberOfItemsInSection section: Int) -> Int
     func collectionSkeletonView(_ skeletonView: UICollectionView, cellIdentifierForItemAt indexPath: IndexPath) -> ReusableCellIdentifier
     func collectionSkeletonView(_ skeletonView: UICollectionView, supplementaryViewIdentifierOfKind: String, at indexPath: IndexPath) -> ReusableCellIdentifier?
+    func collectionSkeletonView(_ skeletonView: UICollectionView, skeletonCellForItemAt indexPath: IndexPath) -> UICollectionViewCell?
 }
 
 public extension SkeletonCollectionViewDataSource {
     func collectionSkeletonView(_ skeletonView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return UICollectionView.automaticNumberOfSkeletonItems
+        UICollectionView.automaticNumberOfSkeletonItems
     }
     
-    func collectionSkeletonView(_ skeletonView: UICollectionView,
-                                supplementaryViewIdentifierOfKind: String,
-                                at indexPath: IndexPath) -> ReusableCellIdentifier? {
-        return nil
+    func collectionSkeletonView(_ skeletonView: UICollectionView, supplementaryViewIdentifierOfKind: String, at indexPath: IndexPath) -> ReusableCellIdentifier? {
+        nil
     }
     
-    func numSections(in collectionSkeletonView: UICollectionView) -> Int { return 1 }
+    func numSections(in collectionSkeletonView: UICollectionView) -> Int {
+        1
+    }
+    
+    func collectionSkeletonView(_ skeletonView: UICollectionView, skeletonCellForItemAt indexPath: IndexPath) -> UICollectionViewCell? {
+        nil
+    }
 }
 
 public protocol SkeletonCollectionViewDelegate: UICollectionViewDelegate { }

--- a/Sources/Collections/SkeletonCollectionDataSource.swift
+++ b/Sources/Collections/SkeletonCollectionDataSource.swift
@@ -46,8 +46,16 @@ extension SkeletonCollectionDataSource: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cellIdentifier = originalTableViewDataSource?.collectionSkeletonView(tableView, cellIdentifierForRowAt: indexPath) ?? ""
-        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
+        guard let cell = originalTableViewDataSource?.collectionSkeletonView(tableView, skeletonCellForRowAt: indexPath) else {
+            let cellIdentifier = originalTableViewDataSource?.collectionSkeletonView(tableView, cellIdentifierForRowAt: indexPath) ?? ""
+            let fakeCell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
+
+            originalTableViewDataSource?.collectionSkeletonViewConfigureCell(fakeCell)
+            skeletonViewIfContainerSkeletonIsActive(container: tableView, view: fakeCell)
+            
+            return fakeCell
+        }
+
         originalTableViewDataSource?.collectionSkeletonViewConfigureCell(cell)
         skeletonViewIfContainerSkeletonIsActive(container: tableView, view: cell)
         return cell
@@ -75,8 +83,15 @@ extension SkeletonCollectionDataSource: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cellIdentifier = originalCollectionViewDataSource?.collectionSkeletonView(collectionView, cellIdentifierForItemAt: indexPath) ?? ""
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellIdentifier, for: indexPath)
+        guard let cell = originalCollectionViewDataSource?.collectionSkeletonView(collectionView, skeletonCellForItemAt: indexPath) else {
+            let cellIdentifier = originalCollectionViewDataSource?.collectionSkeletonView(collectionView, cellIdentifierForItemAt: indexPath) ?? ""
+            let fakeCell = collectionView.dequeueReusableCell(withReuseIdentifier: cellIdentifier, for: indexPath)
+            
+            skeletonViewIfContainerSkeletonIsActive(container: collectionView, view: fakeCell)
+            
+            return fakeCell
+        }
+            
         skeletonViewIfContainerSkeletonIsActive(container: collectionView, view: cell)
         return cell
     }

--- a/Sources/Collections/SkeletonCollectionDataSource.swift
+++ b/Sources/Collections/SkeletonCollectionDataSource.swift
@@ -48,6 +48,7 @@ extension SkeletonCollectionDataSource: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cellIdentifier = originalTableViewDataSource?.collectionSkeletonView(tableView, cellIdentifierForRowAt: indexPath) ?? ""
         let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
+        originalTableViewDataSource?.collectionSkeletonViewConfigureCell(cell)
         skeletonViewIfContainerSkeletonIsActive(container: tableView, view: cell)
         return cell
     }

--- a/Sources/Collections/SkeletonCollectionDataSource.swift
+++ b/Sources/Collections/SkeletonCollectionDataSource.swift
@@ -52,12 +52,13 @@ extension SkeletonCollectionDataSource: UITableViewDataSource {
 
             originalTableViewDataSource?.collectionSkeletonViewConfigureCell(fakeCell)
             skeletonViewIfContainerSkeletonIsActive(container: tableView, view: fakeCell)
-            
+
             return fakeCell
         }
 
         originalTableViewDataSource?.collectionSkeletonViewConfigureCell(cell)
         skeletonViewIfContainerSkeletonIsActive(container: tableView, view: cell)
+
         return cell
     }
 }

--- a/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
+++ b/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
@@ -13,6 +13,7 @@ public protocol SkeletonTableViewDataSource: UITableViewDataSource {
     func collectionSkeletonView(_ skeletonView: UITableView, numberOfRowsInSection section: Int) -> Int
     func collectionSkeletonView(_ skeletonView: UITableView, cellIdentifierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier
     func collectionSkeletonViewConfigureCell(_ cell: UITableViewCell)
+    func collectionSkeletonView(_ skeletonView: UITableView, skeletonCellForRowAt indexPath: IndexPath) -> UITableViewCell?
 }
 
 public extension SkeletonTableViewDataSource {
@@ -30,6 +31,11 @@ public extension SkeletonTableViewDataSource {
     }
 
     func collectionSkeletonViewConfigureCell(_ cell: UITableViewCell) { }
+
+    
+    func collectionSkeletonView(_ skeletonView: UITableView, skeletonCellForRowAt indexPath: IndexPath) -> UITableViewCell? {
+        nil
+    }
 }
 
 public protocol SkeletonTableViewDelegate: UITableViewDelegate {

--- a/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
+++ b/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
@@ -14,7 +14,6 @@ public protocol SkeletonTableViewDataSource: UITableViewDataSource {
     func collectionSkeletonView(_ skeletonView: UITableView, cellIdentifierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier
     func collectionSkeletonViewConfigureCell(_ cell: UITableViewCell)
     func collectionSkeletonView(_ skeletonView: UITableView, skeletonCellForRowAt indexPath: IndexPath) -> UITableViewCell?
-    func collectionSkeletonViewConfigureCell(_ cell: UITableViewCell)
 }
 
 public extension SkeletonTableViewDataSource {
@@ -37,8 +36,6 @@ public extension SkeletonTableViewDataSource {
     func collectionSkeletonView(_ skeletonView: UITableView, skeletonCellForRowAt indexPath: IndexPath) -> UITableViewCell? {
         nil
     }
-
-    func collectionSkeletonViewConfigureCell(_ cell: UITableViewCell) { }
 }
 
 public protocol SkeletonTableViewDelegate: UITableViewDelegate {

--- a/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
+++ b/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
@@ -14,6 +14,7 @@ public protocol SkeletonTableViewDataSource: UITableViewDataSource {
     func collectionSkeletonView(_ skeletonView: UITableView, cellIdentifierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier
     func collectionSkeletonViewConfigureCell(_ cell: UITableViewCell)
     func collectionSkeletonView(_ skeletonView: UITableView, skeletonCellForRowAt indexPath: IndexPath) -> UITableViewCell?
+    func collectionSkeletonViewConfigureCell(_ cell: UITableViewCell)
 }
 
 public extension SkeletonTableViewDataSource {
@@ -36,6 +37,8 @@ public extension SkeletonTableViewDataSource {
     func collectionSkeletonView(_ skeletonView: UITableView, skeletonCellForRowAt indexPath: IndexPath) -> UITableViewCell? {
         nil
     }
+
+    func collectionSkeletonViewConfigureCell(_ cell: UITableViewCell) { }
 }
 
 public protocol SkeletonTableViewDelegate: UITableViewDelegate {

--- a/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
+++ b/Sources/Collections/TableViews/SkeletonTableViewProtocols.swift
@@ -12,6 +12,7 @@ public protocol SkeletonTableViewDataSource: UITableViewDataSource {
     func numSections(in collectionSkeletonView: UITableView) -> Int
     func collectionSkeletonView(_ skeletonView: UITableView, numberOfRowsInSection section: Int) -> Int
     func collectionSkeletonView(_ skeletonView: UITableView, cellIdentifierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier
+    func collectionSkeletonViewConfigureCell(_ cell: UITableViewCell)
 }
 
 public extension SkeletonTableViewDataSource {
@@ -27,6 +28,8 @@ public extension SkeletonTableViewDataSource {
     func collectionSkeletonView(_ skeletonView: UITableView, cellIdenfierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier {
         return collectionSkeletonView(skeletonView, cellIdentifierForRowAt: indexPath)
     }
+
+    func collectionSkeletonViewConfigureCell(_ cell: UITableViewCell) { }
 }
 
 public protocol SkeletonTableViewDelegate: UITableViewDelegate {


### PR DESCRIPTION
Add method "collectionSkeletonViewConfigureCell" to "SkeletonCollectionDataSource". This will allow configuration of the cell before being displayed by SkeletonView.

### Summary

[Issue Link](https://github.com/Juanpe/SkeletonView/issues/412)

### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
