### PR TITLE
Fallback to non-skeleton Header

### DIFF
--- a/Sources/Collections/SkeletonCollectionDataSource.swift
+++ b/Sources/Collections/SkeletonCollectionDataSource.swift
@@ -107,7 +107,7 @@ extension SkeletonCollectionDataSource: UICollectionViewDataSource {
             return view
         }
         
-        return UICollectionReusableView()
+        return originalCollectionViewDataSource?.collectionView?(collectionView, viewForSupplementaryElementOfKind: kind, at: indexPath) ?? UICollectionReusableView()
     }
     
 }


### PR DESCRIPTION
### Summary

Sometimes a collectionview's header doesn't need to be 'skeletoned' since it's already ready to be displayed, while the content needs more time to load.  

When  collectionSkeletonView(_ skeletonView: UICollectionView, supplementaryViewIdentifierOfKind: String, at indexPath: IndexPath) -> ReusableCellIdentifier? returns nil, it's best if we fallback to the non-skeleton, original header.


### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
