### PR TITLE
Fixed bg color warning in `UITableViewHeaderFooterView`

### DIFF
--- a/Sources/Extensions/UIView+Extension.swift
+++ b/Sources/Extensions/UIView+Extension.swift
@@ -14,6 +14,7 @@ enum ViewAssociatedKeys {
     static var labelViewState = "labelViewState"
     static var imageViewState = "imageViewState"
     static var buttonViewState = "buttonViewState"
+    static var headerFooterViewState = "headerFooterViewState"
     static var currentSkeletonConfig = "currentSkeletonConfig"
     static var skeletonCornerRadius = "skeletonCornerRadius"
     static var disabledWhenSkeletonIsActive = "disabledWhenSkeletonIsActive"

--- a/Sources/Helpers/PrepareForSkeletonProtocol.swift
+++ b/Sources/Helpers/PrepareForSkeletonProtocol.swift
@@ -121,3 +121,13 @@ extension UIButton {
         }
     }
 }
+
+extension UITableViewHeaderFooterView {
+    override func prepareViewForSkeleton() {
+        backgroundView?.backgroundColor = .clear
+        
+        if isUserInteractionDisabledWhenSkeletonIsActive {
+            isUserInteractionEnabled = false
+        }
+    }
+}

--- a/Sources/Recoverable/Recoverable.swift
+++ b/Sources/Recoverable/Recoverable.swift
@@ -161,3 +161,22 @@ extension UIButton {
         }
     }
 }
+
+extension UITableViewHeaderFooterView {
+    var headerFooterState: RecoverableTableViewHeaderFooterViewState? {
+        get { return ao_get(pkey: &ViewAssociatedKeys.headerFooterViewState) as? RecoverableTableViewHeaderFooterViewState }
+        set { ao_setOptional(newValue, pkey: &ViewAssociatedKeys.headerFooterViewState) }
+    }
+    
+    override func saveViewState() {
+        super.saveViewState()
+        headerFooterState = RecoverableTableViewHeaderFooterViewState(view: self)
+    }
+    
+    override func recoverViewState(forced: Bool) {
+        super.recoverViewState(forced: forced)
+        startTransition { [weak self] in
+            self?.backgroundView?.backgroundColor = self?.headerFooterState?.backgroundViewColor
+        }
+    }
+}

--- a/Sources/Recoverable/RecoverableViewState.swift
+++ b/Sources/Recoverable/RecoverableViewState.swift
@@ -59,3 +59,11 @@ struct RecoverableButtonViewState {
         self.title = view.titleLabel?.text
     }
 }
+
+struct RecoverableTableViewHeaderFooterViewState {
+    var backgroundViewColor: UIColor?
+    
+    init(view: UITableViewHeaderFooterView) {
+        self.backgroundViewColor = view.backgroundView?.backgroundColor
+    }
+}


### PR DESCRIPTION
### Summary

Fixes #294 

This PR fixes the console warning:

`[TableView] Setting the background color on UITableViewHeaderFooterView has been deprecated. Please set a custom UIView with your desired background color to the backgroundView property instead.`

### Requirements
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
