### PR TITLE
Fix for bug 426

### DIFF
--- a/Sources/Multilines/UILabel+Multiline.swift
+++ b/Sources/Multilines/UILabel+Multiline.swift
@@ -29,7 +29,13 @@ public extension UILabel {
 
 extension UILabel: ContainsMultilineText {    
     var lineHeight: CGFloat {
-        backupHeightConstraints.first?.constant ?? SkeletonAppearance.default.multilineHeight
+        if let fontLineHeight = font?.lineHeight {
+            if let heightConstraints = backupHeightConstraints.first?.constant {
+                return (fontLineHeight > heightConstraints) ? heightConstraints : fontLineHeight
+            }
+            return fontLineHeight
+        }
+        return SkeletonAppearance.default.multilineHeight
     }
     
     var lastLineFillingPercent: Int {


### PR DESCRIPTION
### Summary

Fix for bug #426

### Requirements (place an `x` in each of the `[ ]`)
* [ x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x ] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
