### PR TITLE
Add new property `useFontLineHeight

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,14 @@ By default, the user interaction is disabled for skeletonized items, but if you 
 view.isUserInteractionDisabledWhenSkeletonIsActive = false  // The view will be active when the skeleton will be active.
 ```
 
+**Don't use the font line height for the skeleton lines in labels**
+
+False to disable skeleton to auto-adjust to font height for a `UILabel` or `UITextView`. By default, the skeleton lines height is auto-adjusted to font height to more accurately reflect the text in the label rect rather than using the bounding box.
+
+```swift
+label.useFontLineHeight = false
+```
+
 **Delayed show skeleton**
 
 You can delay the presentation of the skeleton if the views update quickly.

--- a/SkeletonViewCore/Sources/API/UIKitExtensions/UILabel+IBInspectable.swift
+++ b/SkeletonViewCore/Sources/API/UIKitExtensions/UILabel+IBInspectable.swift
@@ -33,4 +33,10 @@ public extension UILabel {
         set { multilineSpacing = newValue }
     }
     
+    @IBInspectable
+    var useFontLineHeight: Bool {
+        get { usesTextHeightForLines }
+        set { usesTextHeightForLines = newValue }
+    }
+    
 }

--- a/SkeletonViewCore/Sources/API/UIKitExtensions/UITextView+IBInspectable.swift
+++ b/SkeletonViewCore/Sources/API/UIKitExtensions/UITextView+IBInspectable.swift
@@ -33,4 +33,10 @@ public extension UITextView {
         set { multilineSpacing = newValue }
     }
     
+    @IBInspectable
+    var useFontLineHeight: Bool {
+        get { usesTextHeightForLines }
+        set { usesTextHeightForLines = newValue }
+    }
+
 }

--- a/SkeletonViewCore/Sources/Internal/SkeletonExtensions/SkeletonTextNode.swift
+++ b/SkeletonViewCore/Sources/Internal/SkeletonExtensions/SkeletonTextNode.swift
@@ -22,27 +22,36 @@ protocol SkeletonTextNode {
     var multilineCornerRadius: Int { get }
     var multilineSpacing: CGFloat { get }
     var paddingInsets: UIEdgeInsets { get }
-    
+    var usesTextHeightForLines: Bool { get }
 }
 
 enum SkeletonTextNodeAssociatedKeys {
+    
     static var lastLineFillingPercent = "lastLineFillingPercent"
     static var multilineCornerRadius = "multilineCornerRadius"
     static var multilineSpacing = "multilineSpacing"
     static var paddingInsets = "paddingInsets"
     static var backupHeightConstraints = "backupHeightConstraints"
+    static var usesTextHeightForLines = "usesTextHeightForLines"
+    
 }
 
 extension UILabel: SkeletonTextNode {
     
     var lineHeight: CGFloat {
-        if let fontLineHeight = font?.lineHeight {
-            if let heightConstraints = backupHeightConstraints.first?.constant {
-                return (fontLineHeight > heightConstraints) ? heightConstraints : fontLineHeight
-            }
-            return fontLineHeight
+        let constraintsLineHeight = backupHeightConstraints.first?.constant ?? SkeletonAppearance.default.multilineHeight
+        
+        if useFontLineHeight,
+           let fontLineHeight = font?.lineHeight {
+            return fontLineHeight > constraintsLineHeight ? constraintsLineHeight : fontLineHeight
+        } else {
+            return constraintsLineHeight
         }
-        return SkeletonAppearance.default.multilineHeight
+    }
+    
+    var usesTextHeightForLines: Bool {
+        get { return ao_get(pkey: &SkeletonTextNodeAssociatedKeys.usesTextHeightForLines) as? Bool ?? true }
+        set { ao_set(newValue, pkey: &SkeletonTextNodeAssociatedKeys.usesTextHeightForLines) }
     }
     
     var lastLineFillingPercent: Int {
@@ -75,15 +84,19 @@ extension UILabel: SkeletonTextNode {
 extension UITextView: SkeletonTextNode {
     
     var lineHeight: CGFloat {
-        if let fontLineHeight = font?.lineHeight {
-            if let heightConstraints = heightConstraints.first?.constant {
-                return (fontLineHeight > heightConstraints) ? heightConstraints : fontLineHeight
-            }
-            
-            return fontLineHeight
-        }
+        let constraintsLineHeight = heightConstraints.first?.constant ?? SkeletonAppearance.default.multilineHeight
         
-        return SkeletonAppearance.default.multilineHeight
+        if useFontLineHeight,
+           let fontLineHeight = font?.lineHeight {
+            return fontLineHeight > constraintsLineHeight ? constraintsLineHeight : fontLineHeight
+        } else {
+            return constraintsLineHeight
+        }
+    }
+    
+    var usesTextHeightForLines: Bool {
+        get { return ao_get(pkey: &SkeletonTextNodeAssociatedKeys.usesTextHeightForLines) as? Bool ?? true }
+        set { ao_set(newValue, pkey: &SkeletonTextNodeAssociatedKeys.usesTextHeightForLines) }
     }
     
     var numberOfLines: Int {


### PR DESCRIPTION
### Summary

Add a new property to disable the auto-adjustment of the skeleton lines height to the font height.

### Requirements
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
