### PR TITLE
Global setter for useFontLineHeight

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ Default values:
   - *default: `SkeletonGradient(baseColor: .skeletonDefault)`*
 - **multilineHeight**: CGFloat
   - *default: 15*
+- **useFontLineHeight**: Bool
+  - *default: true*
 - **multilineSpacing**: CGFloat
   - *default: 10*
 - **multilineLastLineFillPercent**: Int
@@ -315,6 +317,7 @@ You can also specifiy these line appearance properties on a per-label basis:
 - **linesCornerRadius**: Int
 - **skeletonLineSpacing**: CGFloat
 - **skeletonPaddingInsets**: UIEdgeInsets
+- **useFontLineHeight**: Bool
 
 
 ### 🎨 Custom colors

--- a/SkeletonViewCore/Sources/API/Appearance/SkeletonAppearance.swift
+++ b/SkeletonViewCore/Sources/API/Appearance/SkeletonAppearance.swift
@@ -27,6 +27,8 @@ public class SkeletonViewAppearance {
 
     public var multilineHeight: CGFloat = 15
 
+    public var useFontLineHeight: Bool = true
+    
     public var multilineSpacing: CGFloat = 10
 
     public var multilineLastLineFillPercent: Int = 70

--- a/SkeletonViewCore/Sources/Internal/SkeletonExtensions/SkeletonTextNode.swift
+++ b/SkeletonViewCore/Sources/Internal/SkeletonExtensions/SkeletonTextNode.swift
@@ -50,7 +50,7 @@ extension UILabel: SkeletonTextNode {
     }
     
     var usesTextHeightForLines: Bool {
-        get { return ao_get(pkey: &SkeletonTextNodeAssociatedKeys.usesTextHeightForLines) as? Bool ?? true }
+        get { return ao_get(pkey: &SkeletonTextNodeAssociatedKeys.usesTextHeightForLines) as? Bool ?? SkeletonAppearance.default.useFontLineHeight }
         set { ao_set(newValue, pkey: &SkeletonTextNodeAssociatedKeys.usesTextHeightForLines) }
     }
     
@@ -95,7 +95,7 @@ extension UITextView: SkeletonTextNode {
     }
     
     var usesTextHeightForLines: Bool {
-        get { return ao_get(pkey: &SkeletonTextNodeAssociatedKeys.usesTextHeightForLines) as? Bool ?? true }
+        get { return ao_get(pkey: &SkeletonTextNodeAssociatedKeys.usesTextHeightForLines) as? Bool ?? SkeletonAppearance.default.useFontLineHeight }
         set { ao_set(newValue, pkey: &SkeletonTextNodeAssociatedKeys.usesTextHeightForLines) }
     }
     


### PR DESCRIPTION
### Summary
- Add useFontLineHeight to SkeletonViewAppearance.
- Update README file to include useFontLineHeight under SkeletonAppearance.

Closes #452 
### Requirements (place an `x` in each of the `[ ]`)
* [ x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x ] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
