### PR TITLE
Fix skeleton flow notifications triggered multiple times

### DIFF
--- a/SkeletonViewCore/Sources/Internal/Collections/SkeletonCollectionDataSource.swift
+++ b/SkeletonViewCore/Sources/Internal/Collections/SkeletonCollectionDataSource.swift
@@ -51,13 +51,13 @@ extension SkeletonCollectionDataSource: UITableViewDataSource {
             let fakeCell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
 
             originalTableViewDataSource?.collectionSkeletonView(tableView, prepareCellForSkeleton: fakeCell, at: indexPath)
-            skeletonViewIfContainerSkeletonIsActive(container: tableView, view: fakeCell)
+            skeletonizeViewIfContainerSkeletonIsActive(container: tableView, view: fakeCell)
             
             return fakeCell
         }
 
         originalTableViewDataSource?.collectionSkeletonView(tableView, prepareCellForSkeleton: cell, at: indexPath)
-        skeletonViewIfContainerSkeletonIsActive(container: tableView, view: cell)
+        skeletonizeViewIfContainerSkeletonIsActive(container: tableView, view: cell)
         return cell
     }
 }
@@ -88,13 +88,13 @@ extension SkeletonCollectionDataSource: UICollectionViewDataSource {
             let fakeCell = collectionView.dequeueReusableCell(withReuseIdentifier: cellIdentifier, for: indexPath)
 
             originalCollectionViewDataSource?.collectionSkeletonView(collectionView, prepareCellForSkeleton: fakeCell, at: indexPath)
-            skeletonViewIfContainerSkeletonIsActive(container: collectionView, view: fakeCell)
+            skeletonizeViewIfContainerSkeletonIsActive(container: collectionView, view: fakeCell)
             
             return fakeCell
         }
 
         originalCollectionViewDataSource?.collectionSkeletonView(collectionView, prepareCellForSkeleton: cell, at: indexPath)
-        skeletonViewIfContainerSkeletonIsActive(container: collectionView, view: cell)
+        skeletonizeViewIfContainerSkeletonIsActive(container: collectionView, view: cell)
         return cell
     }
     
@@ -103,7 +103,7 @@ extension SkeletonCollectionDataSource: UICollectionViewDataSource {
                         at indexPath: IndexPath) -> UICollectionReusableView {
         if let viewIdentifier = originalCollectionViewDataSource?.collectionSkeletonView(collectionView, supplementaryViewIdentifierOfKind: kind, at: indexPath) {
             let view = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: viewIdentifier, for: indexPath)
-            skeletonViewIfContainerSkeletonIsActive(container: collectionView, view: view)
+            skeletonizeViewIfContainerSkeletonIsActive(container: collectionView, view: view)
             return view
         }
         
@@ -113,12 +113,15 @@ extension SkeletonCollectionDataSource: UICollectionViewDataSource {
 }
 
 extension SkeletonCollectionDataSource {
-    private func skeletonViewIfContainerSkeletonIsActive(container: UIView, view: UIView) {
+    private func skeletonizeViewIfContainerSkeletonIsActive(container: UIView, view: UIView) {
         guard container.sk.isSkeletonActive,
               let skeletonConfig = container._currentSkeletonConfig else {
             return
         }
 
-        view.showSkeleton(skeletonConfig: skeletonConfig)
+        view.showSkeleton(
+            skeletonConfig: skeletonConfig,
+            notifyDelegate: false
+        )
     }
 }

--- a/SkeletonViewCore/Sources/Internal/Collections/SkeletonCollectionDelegate.swift
+++ b/SkeletonViewCore/Sources/Internal/Collections/SkeletonCollectionDelegate.swift
@@ -9,17 +9,23 @@
 import UIKit
 
 class SkeletonCollectionDelegate: NSObject {
+    
     weak var originalTableViewDelegate: SkeletonTableViewDelegate?
     weak var originalCollectionViewDelegate: SkeletonCollectionViewDelegate?
     
-    init(tableViewDelegate: SkeletonTableViewDelegate? = nil, collectionViewDelegate: SkeletonCollectionViewDelegate? = nil) {
+    init(
+        tableViewDelegate: SkeletonTableViewDelegate? = nil,
+        collectionViewDelegate: SkeletonCollectionViewDelegate? = nil
+    ) {
         self.originalTableViewDelegate = tableViewDelegate
         self.originalCollectionViewDelegate = collectionViewDelegate
     }
+    
 }
 
 // MARK: - UITableViewDelegate
 extension SkeletonCollectionDelegate: UITableViewDelegate {
+    
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         headerOrFooterView(tableView, for: originalTableViewDelegate?.collectionSkeletonView(tableView, identifierForHeaderInSection: section))
     }
@@ -42,24 +48,40 @@ extension SkeletonCollectionDelegate: UITableViewDelegate {
         cell.hideSkeleton()
         originalTableViewDelegate?.tableView?(tableView, didEndDisplaying: cell, forRowAt: indexPath)
     }
-
-    private func headerOrFooterView(_ tableView: UITableView, for viewIdentifier: String? ) -> UIView? {
-      guard let viewIdentifier = viewIdentifier, let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: viewIdentifier) else { return nil }
-      skeletonViewIfContainerSkeletonIsActive(container: tableView, view: header)
-      return header
-  }
+    
 }
 
 // MARK: - UICollectionViewDelegate
 extension SkeletonCollectionDelegate: UICollectionViewDelegate { }
 
-extension SkeletonCollectionDelegate {
-    private func skeletonViewIfContainerSkeletonIsActive(container: UIView, view: UIView) {
+private extension SkeletonCollectionDelegate {
+    
+    func skeletonizeViewIfContainerSkeletonIsActive(container: UIView, view: UIView) {
         guard container.sk.isSkeletonActive,
-              let skeletonConfig = container._currentSkeletonConfig else {
+              let skeletonConfig = container._currentSkeletonConfig
+        else {
             return
         }
 
-        view.showSkeleton(skeletonConfig: skeletonConfig)
+        view.showSkeleton(
+            skeletonConfig: skeletonConfig,
+            notifyDelegate: false
+        )
     }
+    
+    func headerOrFooterView(_ tableView: UITableView, for viewIdentifier: String? ) -> UIView? {
+        guard let viewIdentifier = viewIdentifier,
+              let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: viewIdentifier)
+        else {
+            return nil
+        }
+        
+        skeletonizeViewIfContainerSkeletonIsActive(
+            container: tableView,
+            view: header
+        )
+        
+        return header
+    }
+    
 }

--- a/SkeletonViewCore/Sources/Internal/SkeletonFlowHandler.swift
+++ b/SkeletonViewCore/Sources/Internal/SkeletonFlowHandler.swift
@@ -21,15 +21,15 @@ class SkeletonFlowHandler: SkeletonFlowDelegate {
 
     func didShowSkeletons(rootView: UIView) {
         skeletonLog(rootView.sk.skeletonTreeDescription)
-        NotificationCenter.default.post(name: .skeletonWillAppearNotification, object: rootView, userInfo: nil)
+        NotificationCenter.default.post(name: .skeletonDidAppearNotification, object: rootView, userInfo: nil)
     }
 
     func willBeginUpdatingSkeletons(rootView: UIView) {
-        NotificationCenter.default.post(name: .skeletonWillAppearNotification, object: rootView, userInfo: nil)
+        NotificationCenter.default.post(name: .skeletonWillUpdateNotification, object: rootView, userInfo: nil)
     }
 
     func didUpdateSkeletons(rootView: UIView) {
-        NotificationCenter.default.post(name: .skeletonWillAppearNotification, object: rootView, userInfo: nil)
+        NotificationCenter.default.post(name: .skeletonDidUpdateNotification, object: rootView, userInfo: nil)
     }
 
     func willBeginLayingSkeletonsIfNeeded(rootView: UIView) {

--- a/SkeletonViewCore/Sources/Internal/UIKitExtensions/UIView+SkeletonView.swift
+++ b/SkeletonViewCore/Sources/Internal/UIKitExtensions/UIView+SkeletonView.swift
@@ -15,16 +15,30 @@ import UIKit
 
 extension UIView {
     
-    func showSkeleton(skeletonConfig config: SkeletonConfig) {
+    func showSkeleton(
+        skeletonConfig config: SkeletonConfig,
+        notifyDelegate: Bool = true
+    ) {
         _isSkeletonAnimated = config.animated
-        _flowDelegate = SkeletonFlowHandler()
-        _flowDelegate?.willBeginShowingSkeletons(rootView: self)
+        
+        if notifyDelegate {
+            _flowDelegate = SkeletonFlowHandler()
+            _flowDelegate?.willBeginShowingSkeletons(rootView: self)
+        }
+        
         recursiveShowSkeleton(skeletonConfig: config, root: self)
     }
 
-    func updateSkeleton(skeletonConfig config: SkeletonConfig) {
+    func updateSkeleton(
+        skeletonConfig config: SkeletonConfig,
+        notifyDelegate: Bool = true
+    ) {
         _isSkeletonAnimated = config.animated
-        _flowDelegate?.willBeginUpdatingSkeletons(rootView: self)
+        
+        if notifyDelegate {
+            _flowDelegate?.willBeginUpdatingSkeletons(rootView: self)
+        }
+        
         recursiveUpdateSkeleton(skeletonConfig: config, root: self)
     }
 


### PR DESCRIPTION
Resolves #473 

Because some UI events could modify the number of rows is visible, we have to "skeletonize" the cell in the `cellForDraw` method is called. Due to that, the notifications were sent multiple times. The fix consists in to have a flag to indicate if the delegate has to be notified or not.

