### PR TITLE
Fix last line text alignment when using padding insets

### DIFF
--- a/SkeletonViewCore/Sources/Internal/UIKitExtensions/CALayer+Extensions.swift
+++ b/SkeletonViewCore/Sources/Internal/UIKitExtensions/CALayer+Extensions.swift
@@ -88,15 +88,16 @@ extension CALayer {
 
 private extension CALayer {
     
-    func alignLayerFrame(_ rect: CGRect, alignment: NSTextAlignment, isRTL: Bool) -> CGRect {
+    func alignLayerFrame(_ rect: CGRect, paddingInsets: UIEdgeInsets, alignment: NSTextAlignment, isRTL: Bool) -> CGRect {
         var newRect = rect
+        let superlayerWidth = (superlayer?.bounds.width ?? 0)
 
         switch alignment {
         case .natural where isRTL,
              .right:
-            newRect.origin.x = (superlayer?.bounds.width ?? 0) - rect.origin.x - rect.width
+            newRect.origin.x = superlayerWidth - rect.width - paddingInsets.right
         case .center:
-            newRect.origin.x = rect.origin.x + ((superlayer?.bounds.width ?? 0) - rect.width) / 2
+            newRect.origin.x = (superlayerWidth + paddingInsets.left - paddingInsets.right - rect.width) / 2
         case .natural, .left, .justified:
             break
         @unknown default:
@@ -211,7 +212,7 @@ extension CALayer {
                               height: size.height)
 
         if index == totalLines - 1 {
-            frame = alignLayerFrame(newFrame, alignment: alignment, isRTL: isRTL)
+            frame = alignLayerFrame(newFrame, paddingInsets: paddingInsets, alignment: alignment, isRTL: isRTL)
         } else {
             frame = newFrame
         }


### PR DESCRIPTION
### Summary

Fixes #470. In addition to `center`, it turns out `right` alignment was also broken when some padding insets were set.

The solution was more straightforward than I thought. I passed in the `paddingInsets` so we could correctly determine how to align the last line relative to the superlayer. Since the left and right padding could be different, we couldn't derive this from the existing properties.

I simplified the math I originally used to figure out the right and center alignment values. If it is still confusing, I'd be happy to split the calculations over a couple lines and annotate with comments.

I tested by modifying the demo app. I am not too familiar with the project and whether this could be something easily unit tested.

### Screenshots

<details>
<summary>Right Alignment</summary>

| Parameters | Before  | After |
| --- | --- | --- |
| Left Padding: 0<br>Right Padding: 0<br>Percent: 50 | <img src="https://user-images.githubusercontent.com/4574041/148631250-c8b05100-2632-4333-aa1e-77704331e7d3.png" width="200"/> | <img src="https://user-images.githubusercontent.com/4574041/148631491-a04d16f7-31a7-4bc7-a83b-7346bfee3c38.png" width="200"/> |
| Left Padding: 100<br>Right Padding: 100<br>Percent: 50 | <img src="https://user-images.githubusercontent.com/4574041/148631273-742bd84d-e1a9-4308-9d77-70ae4ef80508.png" width="200"/> | <img src="https://user-images.githubusercontent.com/4574041/148631498-45f75b41-e9eb-4100-867e-b75ec059edfd.png" width="200"/> |
| Left Padding: 100<br>Right Padding: 0<br>Percent: 50 | <img src="https://user-images.githubusercontent.com/4574041/148631282-237e47d3-9690-4743-9d02-0c1e85381852.png" width="200"/> | <img src="https://user-images.githubusercontent.com/4574041/148631504-0a387d96-403f-4c3e-9ece-6036327d241f.png" width="200"/> |
| Left Padding: 0<br>Right Padding: 100<br>Percent: 50 | <img src="https://user-images.githubusercontent.com/4574041/148631290-e19f93b3-ca10-47bd-b5d6-26567fd09a5b.png" width="200"/> | <img src="https://user-images.githubusercontent.com/4574041/148631510-f3e69e8f-04cf-4a12-adc0-177e4c88f8fc.png" width="200"/> |
| Left Padding: 50<br>Right Padding: 100<br>Percent: 100 | <img src="https://user-images.githubusercontent.com/4574041/148631305-9297ba30-ebb7-4e4d-b76a-c3c91cf503e9.png" width="200"/> | <img src="https://user-images.githubusercontent.com/4574041/148631522-f0b041c3-766e-452f-ac74-37ffe9419354.png" width="200"/> |

</details>

<details>
<summary>Center Alignment</summary>

| Parameters | Before  | After |
| --- | --- | --- |
| Left Padding: 0<br>Right Padding: 0<br>Percent: 50 | <img src="https://user-images.githubusercontent.com/4574041/148631348-fd56fdde-71fe-434c-a655-b29bf08f70aa.png" width="200"/> | <img src="https://user-images.githubusercontent.com/4574041/148631179-00bb0016-53f6-4411-9a90-d7b6dc42516a.png" width="200"/> |
| Left Padding: 100<br>Right Padding: 100<br>Percent: 50 | <img src="https://user-images.githubusercontent.com/4574041/148631354-02b95c9e-537f-4620-ae67-8e7a2e2f1ea1.png" width="200"/> | <img src="https://user-images.githubusercontent.com/4574041/148631188-a46cf045-cddc-4ef2-8985-c404dc35d1fc.png" width="200"/> |
| Left Padding: 0<br>Right Padding: 0<br>Percent: 100 | <img src="https://user-images.githubusercontent.com/4574041/148631373-4b4dcd77-5169-494a-b2ee-a653a937e767.png" width="200"/> | <img src="https://user-images.githubusercontent.com/4574041/148631197-2a19790b-a374-4c6d-81c8-128510318c22.png" width="200"/> |
| Left Padding: 100<br>Right Padding: 0<br>Percent: 100 | <img src="https://user-images.githubusercontent.com/4574041/148631387-70af19cd-7a13-4419-a01f-8d6857de45bd.png" width="200"/> | <img src="https://user-images.githubusercontent.com/4574041/148631204-c3eea73d-5465-47ed-b40d-aed58f1dc8ed.png" width="200"/> |
| Left Padding: 0<br>Right Padding: 100<br>Percent: 100 | <img src="https://user-images.githubusercontent.com/4574041/148631405-6b290e4c-57f6-478b-971a-61bb67375454.png" width="200"/> | <img src="https://user-images.githubusercontent.com/4574041/148631215-0e1befe9-f9ed-4e50-b222-599449945e02.png" width="200"/> |
| Left Padding: 50<br>Right Padding: 100<br>Percent: 100 | <img src="https://user-images.githubusercontent.com/4574041/148631411-dda79822-a532-4691-912a-2f6c45a83ddc.png" width="200"/> | <img src="https://user-images.githubusercontent.com/4574041/148631224-d15994e1-8306-4716-acc6-84fe6f89cb30.png" width="200"/> |
| Left Padding: 100<br>Right Padding: 100<br>Percent: 100 | <img src="https://user-images.githubusercontent.com/4574041/148631424-2862c244-bbf4-4583-a5df-d57e1d032377.png" width="200"/> | <img src="https://user-images.githubusercontent.com/4574041/148631227-57d6ccab-3472-48c8-b3cb-420034b89632.png" width="200"/> |

</details>

### Requirements

* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
