### PR TITLE
Improved number of lines calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,21 @@ You can set some properties for multilines elements.
 | **skeletonTextNumberOfLines**  | `SkeletonTextNumberOfLines` | `.inherited` | ![](Assets/multiline_corner.png)
 
 <br />
-👩🏻‍🏫 **How to define the number of lines?**
+
+To modify the percent or radius **using code**, set the properties:
+```swift
+descriptionTextView.lastLineFillPercent = 50
+descriptionTextView.linesCornerRadius = 5
+```
+
+Or, if you prefer use **IB/Storyboard**:
+
+![](Assets/multiline_customize.png)
+
+<br />
+
+**How to define the number of lines?**
+
 
 By default, the number of lines is the same as the value of the `numberOfLines` property. And, if it's set to **zero**, it'll calculate how many lines are needed to populate the whole skeleton and draw it.
 
@@ -285,7 +299,6 @@ For example:
 ```swift
 label.skeletonTextNumberOfLines = 3   // .custom(3)
 ``` 
-
 
 <br />
 
@@ -301,18 +314,6 @@ label.skeletonTextNumberOfLines = 3   // .custom(3)
 > Please note that for views without multiple lines, the single line will be considered 
 > as the last line.
 
-
-<br />
-
-To modify the percent or radius **using code**, set the properties:
-```swift
-descriptionTextView.lastLineFillPercent = 50
-descriptionTextView.linesCornerRadius = 5
-```
-
-Or, if you prefer use **IB/Storyboard**:
-
-![](Assets/multiline_customize.png)
 
 
 ### 🦋 Appearance

--- a/README.md
+++ b/README.md
@@ -261,7 +261,6 @@ The rest of the process is the same as ```UITableView```
 ![](Assets/multilines2.png)
 
 When using elements with text, ```SkeletonView``` draws lines to simulate text.
-Besides, you can decide how many lines you want. If  ```numberOfLines``` is set to zero, it will calculate how many lines needed to populate the whole skeleton and it will be drawn. Instead, if you set it to one, two or any number greater than zero, it will only draw this number of lines.
 
 You can set some properties for multilines elements.
 
@@ -272,6 +271,21 @@ You can set some properties for multilines elements.
 | **skeletonLineSpacing**  | `CGFloat` | `10` | ![](Assets/multiline_lineSpacing.png)
 | **skeletonPaddingInsets**  | `UIEdgeInsets` | `.zero` | ![](Assets/multiline_insets.png)
 | **skeletonTextLineHeight**  | `SkeletonTextLineHeight` | `.fixed(15)` | ![](Assets/multiline_lineHeight.png)
+| **skeletonTextNumberOfLines**  | `SkeletonTextNumberOfLines` | `.inherited` | ![](Assets/multiline_corner.png)
+
+<br />
+👩🏻‍🏫 **How to define the number of lines?**
+
+By default, the number of lines is the same as the value of the `numberOfLines` property. And, if it's set to **zero**, it'll calculate how many lines are needed to populate the whole skeleton and draw it.
+
+However, if you want to set a specific number of skeleton lines you can do it by setting the `skeletonTextNumberOfLines` property. This property has two possible values, `inherited` which returns `numberOfLines` value and `custom(Int)` which returns the specific number of lines specified as the associated value. 
+
+For example:
+
+```swift
+label.skeletonTextNumberOfLines = 3   // .custom(3)
+``` 
+
 
 <br />
 

--- a/SkeletonView.xcodeproj/project.pbxproj
+++ b/SkeletonView.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		F5225F2A278C2BCE0061A9B0 /* SkeletonTextNumberOfLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5225F29278C2BCE0061A9B0 /* SkeletonTextNumberOfLines.swift */; };
+		F5225F2B278C2BCE0061A9B0 /* SkeletonTextNumberOfLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5225F29278C2BCE0061A9B0 /* SkeletonTextNumberOfLines.swift */; };
 		F53D731826D399E100249D46 /* SkeletonTreeNode+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53D731726D399E100249D46 /* SkeletonTreeNode+Extensions.swift */; };
 		F53D731926D399E100249D46 /* SkeletonTreeNode+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53D731726D399E100249D46 /* SkeletonTreeNode+Extensions.swift */; };
 		F53D731B26D3A35100249D46 /* SkeletonExtended.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53D731A26D3A35100249D46 /* SkeletonExtended.swift */; };
@@ -151,6 +153,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		F5225F29278C2BCE0061A9B0 /* SkeletonTextNumberOfLines.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonTextNumberOfLines.swift; sourceTree = "<group>"; };
 		F53D731726D399E100249D46 /* SkeletonTreeNode+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SkeletonTreeNode+Extensions.swift"; sourceTree = "<group>"; };
 		F53D731A26D3A35100249D46 /* SkeletonExtended.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonExtended.swift; sourceTree = "<group>"; };
 		F53D732226D3C3A800249D46 /* UILabel+SKExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+SKExtensions.swift"; sourceTree = "<group>"; };
@@ -519,6 +522,7 @@
 				F556F6B826CE262700A80B83 /* GradientDirection.swift */,
 				F556F6C126CE27FD00A80B83 /* SkeletonType.swift */,
 				F5C84883274BB6F000004D1A /* SkeletonTextLineHeight.swift */,
+				F5225F29278C2BCE0061A9B0 /* SkeletonTextNumberOfLines.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -834,6 +838,7 @@
 				F556F58A26CD1F3900A80B83 /* SkeletonGradient.swift in Sources */,
 				F556F6C326CE27FD00A80B83 /* SkeletonType.swift in Sources */,
 				F556F58B26CD1F3900A80B83 /* SkeletonLayer.swift in Sources */,
+				F5225F2B278C2BCE0061A9B0 /* SkeletonTextNumberOfLines.swift in Sources */,
 				F556F6A226CD566C00A80B83 /* UIView+SKExtensions.swift in Sources */,
 				F556F69326CD506C00A80B83 /* Deprecated.swift in Sources */,
 				F556F6BA26CE262700A80B83 /* GradientDirection.swift in Sources */,
@@ -917,6 +922,7 @@
 				F556F6C226CE27FD00A80B83 /* SkeletonType.swift in Sources */,
 				OBJ_123 /* SkeletonLayer.swift in Sources */,
 				F556F6E026CE367600A80B83 /* UIView+SkeletonView.swift in Sources */,
+				F5225F2A278C2BCE0061A9B0 /* SkeletonTextNumberOfLines.swift in Sources */,
 				F556F6A126CD566C00A80B83 /* UIView+SKExtensions.swift in Sources */,
 				F556F69226CD506C00A80B83 /* Deprecated.swift in Sources */,
 				F556F6B926CE262700A80B83 /* GradientDirection.swift in Sources */,

--- a/SkeletonViewCore/Sources/API/Models/SkeletonTextNumberOfLines.swift
+++ b/SkeletonViewCore/Sources/API/Models/SkeletonTextNumberOfLines.swift
@@ -1,0 +1,32 @@
+//
+//  Copyright SkeletonView. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SkeletonTextNumberOfLines.swift
+//
+//  Created by Juanpe Catalán on 10/1/22.
+
+import UIKit
+
+public enum SkeletonTextNumberOfLines: Equatable, ExpressibleByIntegerLiteral {
+    
+    /// Returns `numberOfLines` value.
+    case inherited
+    
+    /// Returns the specific number of lines specified as the associated value.
+    case custom(Int)
+    
+}
+
+public extension SkeletonTextNumberOfLines {
+    
+    init(integerLiteral value: Int) {
+        self = .custom(value)
+    }
+    
+}

--- a/SkeletonViewCore/Sources/API/UIKitExtensions/UILabel+SKExtensions.swift
+++ b/SkeletonViewCore/Sources/API/UIKitExtensions/UILabel+SKExtensions.swift
@@ -15,6 +15,7 @@ import UIKit
 
 public extension UILabel {
     
+    /// Defines the skeleton paddings.
     var skeletonPaddingInsets: UIEdgeInsets {
         get {
             paddingInsets
@@ -24,12 +25,25 @@ public extension UILabel {
         }
     }
     
+    /// Defines the logic for calculating the height of the skeleton lines.
+    /// Default: `SkeletonAppearance.default.textLineHeight`
     var skeletonTextLineHeight: SkeletonTextLineHeight {
         get {
             textLineHeight
         }
         set {
             textLineHeight = newValue
+        }
+    }
+    
+    /// Defines the logic for calculating the number of lines of the skeleton.
+    /// Default: `inherited`
+    var skeletonTextNumberOfLines: SkeletonTextNumberOfLines {
+        get {
+            skeletonNumberOfLines
+        }
+        set {
+            skeletonNumberOfLines = newValue
         }
     }
     

--- a/SkeletonViewCore/Sources/API/UIKitExtensions/UITextView+SKExtensions.swift
+++ b/SkeletonViewCore/Sources/API/UIKitExtensions/UITextView+SKExtensions.swift
@@ -15,6 +15,7 @@ import UIKit
 
 public extension UITextView {
 
+    /// Defines the skeleton paddings.
     var skeletonPaddingInsets: UIEdgeInsets {
         get {
             paddingInsets
@@ -24,12 +25,25 @@ public extension UITextView {
         }
     }
     
+    /// Defines the logic for calculating the height of the skeleton lines.
+    /// Default: `SkeletonAppearance.default.textLineHeight`
     var skeletonTextLineHeight: SkeletonTextLineHeight {
         get {
             textLineHeight
         }
         set {
             textLineHeight = newValue
+        }
+    }
+    
+    /// Defines the logic for calculating the number of lines of the skeleton.
+    /// Default: `inherited`
+    var skeletonTextNumberOfLines: SkeletonTextNumberOfLines {
+        get {
+            skeletonNumberOfLines
+        }
+        set {
+            skeletonNumberOfLines = newValue
         }
     }
     

--- a/SkeletonViewCore/Sources/Internal/Models/SkeletonLayer.swift
+++ b/SkeletonViewCore/Sources/Internal/Models/SkeletonLayer.swift
@@ -59,7 +59,7 @@ struct SkeletonLayer {
     /// If there is more than one line, or custom preferences have been set for a single line, draw custom layers
     func addTextLinesIfNeeded() {
         guard let textView = holderAsTextView else { return }
-        let config = SkeletonMultilinesLayerConfig(lines: textView.numberOfLines,
+        let config = SkeletonMultilinesLayerConfig(lines: textView.estimatedNumberOfLines,
                                                    lineHeight: textView.estimatedLineHeight,
                                                    type: type,
                                                    lastLineFillPercent: textView.lastLineFillingPercent,
@@ -75,7 +75,7 @@ struct SkeletonLayer {
     
     func updateLinesIfNeeded() {
         guard let textView = holderAsTextView else { return }
-        let config = SkeletonMultilinesLayerConfig(lines: textView.numberOfLines,
+        let config = SkeletonMultilinesLayerConfig(lines: textView.estimatedNumberOfLines,
                                                    lineHeight: textView.estimatedLineHeight,
                                                    type: type,
                                                    lastLineFillPercent: textView.lastLineFillingPercent,
@@ -91,7 +91,7 @@ struct SkeletonLayer {
     
     var holderAsTextView: SkeletonTextNode? {
         guard let textView = holder as? SkeletonTextNode,
-            (textView.numberOfLines == -1 || textView.numberOfLines == 0 || textView.numberOfLines > 1 || textView.numberOfLines == 1 && !SkeletonAppearance.default.renderSingleLineAsView) else {
+            (textView.estimatedNumberOfLines == -1 || textView.estimatedNumberOfLines == 0 || textView.estimatedNumberOfLines > 1 || textView.estimatedNumberOfLines == 1 && !SkeletonAppearance.default.renderSingleLineAsView) else {
                 return nil
         }
         return textView

--- a/SkeletonViewCore/Sources/Internal/SkeletonExtensions/SkeletonTextNode.swift
+++ b/SkeletonViewCore/Sources/Internal/SkeletonExtensions/SkeletonTextNode.swift
@@ -17,7 +17,7 @@ protocol SkeletonTextNode {
     
     var textLineHeight: SkeletonTextLineHeight { get }
     var estimatedLineHeight: CGFloat { get }
-    var numberOfLines: Int { get }
+    var estimatedNumberOfLines: Int { get }
     var textAlignment: NSTextAlignment { get }
     var lastLineFillingPercent: Int { get }
     var multilineCornerRadius: Int { get }
@@ -35,6 +35,7 @@ enum SkeletonTextNodeAssociatedKeys {
     static var paddingInsets = "paddingInsets"
     static var backupHeightConstraints = "backupHeightConstraints"
     static var textLineHeight = "textLineHeight"
+    static var skeletonNumberOfLines = "skeletonNumberOfLines"
     
 }
 
@@ -48,17 +49,31 @@ extension UILabel: SkeletonTextNode {
             return fontLineHeight ?? SkeletonAppearance.default.multilineHeight
         case .relativeToConstraints:
             guard let constraintsLineHeight = heightConstraints.first?.constant,
-                    numberOfLines != 0 else {
+                  estimatedNumberOfLines != 0 else {
                 return SkeletonAppearance.default.multilineHeight
             }
             
-            return constraintsLineHeight / CGFloat(numberOfLines)
+            return constraintsLineHeight / CGFloat(estimatedNumberOfLines)
         }
     }
     
     var textLineHeight: SkeletonTextLineHeight {
         get { return ao_get(pkey: &SkeletonTextNodeAssociatedKeys.textLineHeight) as? SkeletonTextLineHeight ?? SkeletonAppearance.default.textLineHeight }
         set { ao_set(newValue, pkey: &SkeletonTextNodeAssociatedKeys.textLineHeight) }
+    }
+    
+    var skeletonNumberOfLines: SkeletonTextNumberOfLines {
+        get { return ao_get(pkey: &SkeletonTextNodeAssociatedKeys.skeletonNumberOfLines) as? SkeletonTextNumberOfLines ?? SkeletonTextNumberOfLines.inherited }
+        set { ao_set(newValue, pkey: &SkeletonTextNodeAssociatedKeys.skeletonNumberOfLines) }
+    }
+    
+    var estimatedNumberOfLines: Int {
+        switch skeletonNumberOfLines {
+        case .inherited:
+            return numberOfLines
+        case .custom(let lines):
+            return lines >= 0 ? lines : 1
+        }
     }
     
     var lastLineFillingPercent: Int {
@@ -119,8 +134,18 @@ extension UITextView: SkeletonTextNode {
         set { ao_set(newValue, pkey: &SkeletonTextNodeAssociatedKeys.textLineHeight) }
     }
     
-    var numberOfLines: Int {
-        -1
+    var skeletonNumberOfLines: SkeletonTextNumberOfLines {
+        get { return ao_get(pkey: &SkeletonTextNodeAssociatedKeys.skeletonNumberOfLines) as? SkeletonTextNumberOfLines ?? SkeletonTextNumberOfLines.inherited }
+        set { ao_set(newValue, pkey: &SkeletonTextNodeAssociatedKeys.skeletonNumberOfLines) }
+    }
+    
+    var estimatedNumberOfLines: Int {
+        switch skeletonNumberOfLines {
+        case .inherited:
+            return -1
+        case .custom(let lines):
+            return lines >= -1 ? lines : 1
+        }
     }
     
     var lastLineFillingPercent: Int {

--- a/SkeletonViewCore/Sources/Internal/UIKitExtensions/UILabel+Extensions.swift
+++ b/SkeletonViewCore/Sources/Internal/UIKitExtensions/UILabel+Extensions.swift
@@ -16,15 +16,15 @@ import UIKit
 extension UILabel {
     
     var desiredHeightBasedOnNumberOfLines: CGFloat {
-        let spaceNeededForEachLine = estimatedLineHeight * CGFloat(numberOfLines)
-        let spaceNeededForSpaces = skeletonLineSpacing * CGFloat(numberOfLines - 1)
+        let spaceNeededForEachLine = estimatedLineHeight * CGFloat(estimatedNumberOfLines)
+        let spaceNeededForSpaces = skeletonLineSpacing * CGFloat(estimatedNumberOfLines - 1)
         let padding = paddingInsets.top + paddingInsets.bottom
         
         return spaceNeededForEachLine + spaceNeededForSpaces + padding
     }
     
     func updateHeightConstraintsIfNeeded() {
-        guard numberOfLines > 1 || numberOfLines == 0 else { return }
+        guard estimatedNumberOfLines > 1 || estimatedNumberOfLines == 0 else { return }
         
         // Workaround to simulate content when the label is contained in a `UIStackView`.
         if isSuperviewAStackView, bounds.height == 0 {


### PR DESCRIPTION
### Summary

The goal of this PR is to improve how the number of lines for text nodes is calculated. Until now, the library decided to use the value of the `numberOfLines` property. Now, exist a new type to define how the library should calculate the number.

#### Before
You could set the number of lines by setting the `numberOfLines` property:
```swift
label.numberOfLines = 2

/// Both the label and the skeleton have 2 lines
```

#### After
Now, you can be more specific:
```swift
label.numberOfLines = 2
label.skeletonTextNumberOfLines = 1

/// The label has 2 lines but the skeleton has only one.
```

Here the `SkeletonTextNumberOfLines` definition:
```swift
enum SkeletonTextNumberOfLines {
    
    /// Returns `numberOfLines` value.
    case inherited
    
    /// Returns the specific number of lines specified as the associated value.
    case custom(Int)
    
}
```
