### PR TITLE
Allow to create gradients with an array of colours

### DIFF
--- a/SkeletonViewCore/Sources/API/Models/SkeletonGradient.swift
+++ b/SkeletonViewCore/Sources/API/Models/SkeletonGradient.swift
@@ -29,4 +29,8 @@ public struct SkeletonGradient {
         }
     }
     
+    public init(colors: [UIColor]) {
+        self.gradientColors = colors
+    }
+    
 }


### PR DESCRIPTION
Resolves #461 

### Summary

Small PR to allow the creation of a gradient with a series of colours, instead of just the base colour and the complementary colour.

```swift
SkeletonGradient(colors: [.red, .blue, .green, .yellow, .alizarin, .carrot, .darkGray])
```

