### PR TITLE
Fix animation when the transition is `.none`

### DIFF
--- a/SkeletonViewCore/Sources/Internal/UIKitExtensions/CALayer+Extensions.swift
+++ b/SkeletonViewCore/Sources/Internal/UIKitExtensions/CALayer+Extensions.swift
@@ -78,7 +78,7 @@ extension CALayer {
         insertSublayer(sublayer.contentLayer, at: index)
         switch transition {
         case .none:
-            completion?()
+            DispatchQueue.main.async { completion?() }
         case .crossDissolve(let duration):
             sublayer.contentLayer.setOpacity(from: 0, to: 1, duration: duration, completion: completion)
         }


### PR DESCRIPTION
Resolves #459 

### Summary

When the skeleton appears without transition the constraints are animated too. This solution enqueues the completion in the main thread.