### PR TITLE
Fix crash when text is empty

### DIFF
--- a/SkeletonViewCore/Sources/Internal/SkeletonExtensions/SkeletonTextNode.swift
+++ b/SkeletonViewCore/Sources/Internal/SkeletonExtensions/SkeletonTextNode.swift
@@ -106,9 +106,11 @@ extension UILabel: SkeletonTextNode {
     }
     
     var fontLineHeight: CGFloat? {
-        if let attributes = attributedText?.attributes(at: 0, effectiveRange: nil),
-           let fontAttribute = attributes.first(where: { $0.key == .font }) {
-            return fontAttribute.value as? CGFloat ?? font.lineHeight
+        if let attributedText = attributedText,
+           attributedText.length > 0 {
+            let attributes = attributedText.attributes(at: 0, effectiveRange: nil)
+            let fontAttribute = attributes.first(where: { $0.key == .font })
+            return fontAttribute?.value as? CGFloat ?? font.lineHeight
         } else {
             return font.lineHeight
         }
@@ -179,9 +181,11 @@ extension UITextView: SkeletonTextNode {
     }
     
     var fontLineHeight: CGFloat? {
-        if let attributes = attributedText?.attributes(at: 0, effectiveRange: nil),
-           let fontAttribute = attributes.first(where: { $0.key == .font }) {
-            return fontAttribute.value as? CGFloat ?? font?.lineHeight
+        if let attributedText = attributedText,
+           attributedText.length > 0 {
+            let attributes = attributedText.attributes(at: 0, effectiveRange: nil)
+            let fontAttribute = attributes.first(where: { $0.key == .font })
+            return fontAttribute?.value as? CGFloat ?? font?.lineHeight
         } else {
             return font?.lineHeight
         }


### PR DESCRIPTION
### Summary

Resolves #482 

Now, if a label or textView is empty the app crashes. So, I check if the text is not empty before to get the attributes to estimate the number of lines.
