### PR TITLE
Fix "Hide skeleton" UIButton invisible in iOS Example

### DIFF
--- a/Examples/iOS Example/Sources/Base.lproj/Main.storyboard
+++ b/Examples/iOS Example/Sources/Base.lproj/Main.storyboard
@@ -218,7 +218,9 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tdu-YQ-saq">
                                         <rect key="frame" x="263" y="69" width="94" height="30"/>
-                                        <state key="normal" title="Hide skeleton"/>
+                                        <state key="normal" title="Hide skeleton">
+                                            <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
                                         <connections>
                                             <action selector="showOrHideSkeleton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ma1-WX-Dzy"/>
                                         </connections>


### PR DESCRIPTION
### Summary

Fix "Hide skeleton" UIButton invisible in iOS Example

### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
