### PR TITLE
Bug: CGColor from dynamic UIColor

### DIFF
--- a/SkeletonViewCore/Sources/Internal/Models/SkeletonLayer.swift
+++ b/SkeletonViewCore/Sources/Internal/Models/SkeletonLayer.swift
@@ -28,12 +28,12 @@ struct SkeletonLayer {
         self.maskLayer.bounds = holder.definedMaxBounds
         self.maskLayer.cornerRadius = CGFloat(holder.skeletonCornerRadius)
         addTextLinesIfNeeded()
-        self.maskLayer.tint(withColors: colors)
+        self.maskLayer.tint(withColors: colors, traitCollection: holder.traitCollection)
     }
     
     func update(usingColors colors: [UIColor]) {
         layoutIfNeeded()
-        maskLayer.tint(withColors: colors)
+        maskLayer.tint(withColors: colors, traitCollection: holder?.traitCollection)
     }
 
     func layoutIfNeeded() {

--- a/SkeletonViewCore/Sources/Internal/UIKitExtensions/CALayer+Extensions.swift
+++ b/SkeletonViewCore/Sources/Internal/UIKitExtensions/CALayer+Extensions.swift
@@ -15,11 +15,15 @@ import UIKit
 
 extension CAGradientLayer {
     
-    override func tint(withColors colors: [UIColor]) {
+    override func tint(withColors colors: [UIColor], traitCollection: UITraitCollection?) {
         skeletonSublayers.recursiveSearch(leafBlock: {
-            self.colors = colors.map { $0.cgColor }
+            if #available(iOS 13.0, tvOS 13, *), let traitCollection = traitCollection {
+                self.colors = colors.map { $0.resolvedColor(with: traitCollection).cgColor }
+            } else {
+                self.colors = colors.map { $0.cgColor }
+            }
         }) {
-            $0.tint(withColors: colors)
+            $0.tint(withColors: colors, traitCollection: traitCollection)
         }
     }
     
@@ -35,11 +39,15 @@ extension CALayer {
         return sublayers?.filter { $0.name == Constants.skeletonSubLayersName } ?? [CALayer]()
     }
     
-    @objc func tint(withColors colors: [UIColor]) {
+    @objc func tint(withColors colors: [UIColor], traitCollection: UITraitCollection?) {
         skeletonSublayers.recursiveSearch(leafBlock: {
-            backgroundColor = colors.first?.cgColor
+            if #available(iOS 13.0, tvOS 13, *), let traitCollection = traitCollection {
+                backgroundColor = colors.first?.resolvedColor(with: traitCollection).cgColor
+            } else {
+                backgroundColor = colors.first?.cgColor
+            }
         }) {
-            $0.tint(withColors: colors)
+            $0.tint(withColors: colors, traitCollection: traitCollection)
         }
     }
     

--- a/SkeletonViewCore/Sources/Internal/UIKitExtensions/UIColor+Skeleton.swift
+++ b/SkeletonViewCore/Sources/Internal/UIKitExtensions/UIColor+Skeleton.swift
@@ -43,7 +43,13 @@ public extension UIColor {
     }
     
     var complementaryColor: UIColor {
-        isLight ? darker : lighter
+        if #available(iOS 13, tvOS 13, *) {
+            return UIColor { _ in
+                self.isLight ? self.darker : self.lighter
+            }
+        } else {
+            return isLight ? darker : lighter
+        }
     }
     
     var lighter: UIColor {


### PR DESCRIPTION
Resolves #487 

### Summary

When CGColor was taken from a dynamic UIColor the system theme was always used.
```swift
tableview.overrideUserInterfaceStyle = .dark
```

**Before**: 
<img src="https://user-images.githubusercontent.com/9296457/161150068-1a25c5f4-3dba-4c51-8062-2b982790f90d.png" width="300">   <img src="https://user-images.githubusercontent.com/9296457/161150079-51a5b0fb-e5a7-44e1-a0f6-320e8b045eaa.png" width="300">


**After**:
<img src="https://user-images.githubusercontent.com/9296457/161150089-65bb44c6-80ba-4e7e-8887-fba9856f132a.png" width="300">   <img src="https://user-images.githubusercontent.com/9296457/161150093-50b4a5e2-6e42-4141-88f1-25d7a6752667.png" width="300">


### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
