### PR TITLE
Fix `UIButton` prepare/recover and improve `.none` transition

### DIFF
--- a/SkeletonViewCore/Sources/Internal/Models/RecoverableViewState.swift
+++ b/SkeletonViewCore/Sources/Internal/Models/RecoverableViewState.swift
@@ -13,12 +13,14 @@ struct RecoverableViewState {
     var backgroundColor: UIColor?
     var cornerRadius: CGFloat
     var clipToBounds: Bool
+    var borderColor: CGColor?
     var isUserInteractionsEnabled: Bool
     
     init(view: UIView) {
         self.backgroundColor = view.backgroundColor
         self.clipToBounds = view.layer.masksToBounds
         self.cornerRadius = view.layer.cornerRadius
+        self.borderColor = view.layer.borderColor
         self.isUserInteractionsEnabled = view.isUserInteractionEnabled
     }
     
@@ -70,10 +72,20 @@ struct RecoverableImageViewState {
 }
 
 struct RecoverableButtonViewState {
+    var state: UIControl.State
+    var attributedTitle: NSAttributedString?
     var title: String?
+    var titleColor: UIColor?
+    var image: UIImage?
+    var backgroundImage: UIImage?
     
     init(view: UIButton) {
-        self.title = view.titleLabel?.text
+        self.state = view.state
+        self.attributedTitle = view.attributedTitle(for: state)
+        self.title = view.title(for: state)
+        self.titleColor = view.titleColor(for: state)
+        self.image = view.image(for: state)
+        self.backgroundImage = view.backgroundImage(for: state)
     }
 }
 

--- a/SkeletonViewCore/Sources/Internal/Models/SkeletonLayer.swift
+++ b/SkeletonViewCore/Sources/Internal/Models/SkeletonLayer.swift
@@ -27,6 +27,7 @@ struct SkeletonLayer {
         self.maskLayer.anchorPoint = .zero
         self.maskLayer.bounds = holder.definedMaxBounds
         self.maskLayer.cornerRadius = CGFloat(holder.skeletonCornerRadius)
+        self.maskLayer.zPosition = CGFloat(Float.greatestFiniteMagnitude) // CoreAnimation complains if CGFloat is used
         addTextLinesIfNeeded()
         self.maskLayer.tint(withColors: colors, traitCollection: holder.traitCollection)
     }

--- a/SkeletonViewCore/Sources/Internal/SkeletonExtensions/PrepareViewForSkeleton.swift
+++ b/SkeletonViewCore/Sources/Internal/SkeletonExtensions/PrepareViewForSkeleton.swift
@@ -22,6 +22,7 @@ extension UIView {
         
         startTransition { [weak self] in
             self?.backgroundColor = .clear
+            self?.layer.borderColor = nil
         }
     }
     
@@ -101,7 +102,13 @@ extension UIButton {
         }
         
         startTransition { [weak self] in
-            self?.setTitle(nil, for: .normal)
+            guard let self = self else { return }
+
+            self.setTitle(nil, for: self.state)
+            self.setTitleColor(nil, for: self.state)
+            self.setAttributedTitle(nil, for: self.state)
+            self.setImage(nil, for: self.state)
+            self.setBackgroundImage(nil, for: self.state)
         }
     }
     

--- a/SkeletonViewCore/Sources/Internal/SkeletonExtensions/Recoverable.swift
+++ b/SkeletonViewCore/Sources/Internal/SkeletonExtensions/Recoverable.swift
@@ -32,6 +32,7 @@ extension UIView: Recoverable {
             
             self.layer.cornerRadius = storedViewState.cornerRadius
             self.layer.masksToBounds = storedViewState.clipToBounds
+            self.layer.borderColor = storedViewState.borderColor
             
             if self.isUserInteractionDisabledWhenSkeletonIsActive {
                 self.isUserInteractionEnabled = storedViewState.isUserInteractionsEnabled
@@ -177,8 +178,26 @@ extension UIButton {
     override func recoverViewState(forced: Bool) {
         super.recoverViewState(forced: forced)
         startTransition { [weak self] in
-            if self?.title(for: .normal) == nil {
-                self?.setTitle(self?.buttonState?.title, for: .normal)
+            guard let self = self, let buttonState = self.buttonState else { return }
+
+            let state = buttonState.state
+
+            if let attributedTitle = buttonState.attributedTitle, self.attributedTitle(for: state) == nil || forced {
+                self.setAttributedTitle(attributedTitle, for: state)
+            } else if let title = buttonState.title, self.title(for: state) == nil || forced {
+                self.setTitle(title, for: state)
+
+                if let titleColor = buttonState.titleColor, self.titleColor(for: state) == nil || forced {
+                    self.setTitleColor(titleColor, for: state)
+                }
+            }
+
+            if let image = buttonState.image, self.image(for: state) == nil || forced {
+                self.setImage(image, for: state)
+            }
+
+            if let backgroundImage = buttonState.backgroundImage, self.backgroundImage(for: state) == nil || forced {
+                self.setBackgroundImage(backgroundImage, for: state)
             }
         }
     }

--- a/SkeletonViewCore/Sources/Internal/UIKitExtensions/CALayer+Extensions.swift
+++ b/SkeletonViewCore/Sources/Internal/UIKitExtensions/CALayer+Extensions.swift
@@ -51,12 +51,14 @@ extension CALayer {
         }
     }
     
-    func playAnimation(_ anim: SkeletonLayerAnimation, key: String, completion: (() -> Void)? = nil) {
+    func playAnimation(_ anim: @escaping SkeletonLayerAnimation, key: String, completion: (() -> Void)? = nil) {
         skeletonSublayers.recursiveSearch(leafBlock: {
-            DispatchQueue.main.async { CATransaction.begin() }
-            DispatchQueue.main.async { CATransaction.setCompletionBlock(completion) }
-            add(anim(self), forKey: key)
-            DispatchQueue.main.async { CATransaction.commit() }
+            DispatchQueue.main.async {
+                CATransaction.begin()
+                CATransaction.setCompletionBlock(completion)
+                self.add(anim(self), forKey: key)
+                CATransaction.commit()
+            }
         }) {
             $0.playAnimation(anim, key: key, completion: completion)
         }
@@ -71,15 +73,17 @@ extension CALayer {
     }
     
     func setOpacity(from: Int, to: Int, duration: TimeInterval, completion: (() -> Void)?) {
-        DispatchQueue.main.async { CATransaction.begin() }
-        let animation = CABasicAnimation(keyPath: #keyPath(CALayer.opacity))
-        animation.fromValue = from
-        animation.toValue = to
-        animation.duration = duration
-        animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
-        DispatchQueue.main.async { CATransaction.setCompletionBlock(completion) }
-        add(animation, forKey: "setOpacityAnimation")
-        DispatchQueue.main.async { CATransaction.commit() }
+        DispatchQueue.main.async {
+            CATransaction.begin()
+            CATransaction.setCompletionBlock(completion)
+            let animation = CABasicAnimation(keyPath: #keyPath(CALayer.opacity))
+            animation.fromValue = from
+            animation.toValue = to
+            animation.duration = duration
+            animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
+            self.add(animation, forKey: "setOpacityAnimation")
+            CATransaction.commit()
+        }
     }
     
     func insertSkeletonLayer(_ sublayer: SkeletonLayer, atIndex index: UInt32, transition: SkeletonTransitionStyle, completion: (() -> Void)? = nil) {

--- a/SkeletonViewCore/Sources/Internal/UIKitExtensions/UIView+Transitions.swift
+++ b/SkeletonViewCore/Sources/Internal/UIKitExtensions/UIView+Transitions.swift
@@ -7,7 +7,7 @@ extension UIView {
     func startTransition(transitionBlock: @escaping () -> Void) {
         guard let transitionStyle = _currentSkeletonConfig?.transition,
               transitionStyle != .none else {
-            transitionBlock()
+            UIView.performWithoutAnimation(transitionBlock)
             return
         }
         


### PR DESCRIPTION
### Summary

The current `RecoverableButtonViewState` model only works for very simple buttons where just the title is defined. This means that on more complex scenarios buttons aren't properly "prepared" to enter skeleton mode and remain visible for a while until they are covered with the skeleton layer, where the remaining elements are already in skeleton mode (e.g. labels). Furthermore, when configuring styling on buttons they reorder subviews/sublayers so that the skeleton layer didn't always show on top.

Same thing is true if `layer.borderColor` is non-nil - the border can be seen for a while until the skeleton layer covers it.

Additionally, using `SkeletonTransitionStyle.none` would still allow animations to be performed if any change done in
`prepareViewForSkeleton` triggers a layout pass. This is especially noticeable when pushing a screen in a navigation controller and enabling skeleton mode in `viewDidLoad`.

### Changes

- Add `state`, `attributedTitle`, `titleColor`, `image` and `backgroundImage` to `RecoverableButtonViewState`, clear them on `prepareViewForSkeleton` and recover them on `recoverViewState` (according to `state`).

- Set the `SkeletonLayer.maskLayer`'s `zPosition` to `Float.greatestFiniteMagnitude` so that it always sits on top of the view's content.

- Add `borderColor` to `RecoverableViewState`, clear it on `prepareViewForSkeleton` and recover it in `recoverViewState`.

- Wrap `startTransition` block in a `UIView.performWithoutAnimation` when `SkeletonTransitionStyle.none`.

- Fix `DispatchQueue.main` usage in `CALayer` animation extensions.

### Demo

https://user-images.githubusercontent.com/1391324/202869650-e0f87962-f7a7-451e-b218-64d54b9cb86b.mov

https://user-images.githubusercontent.com/1391324/202869594-e5bc47c6-0687-4fcc-9c54-103919b6a1d4.mov


### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
