### PR TITLE
Delete some Apple private API

### DIFF
--- a/SkeletonViewCore/Sources/Internal/SkeletonExtensions/SubviewsSkeletonables.swift
+++ b/SkeletonViewCore/Sources/Internal/SkeletonExtensions/SubviewsSkeletonables.swift
@@ -25,7 +25,7 @@ extension UITableView {
         var result = [UIView]()
 
         for subview in subviews {
-            if String(describing: type(of: subview)) == "UITableViewWrapperView" {
+            if let superview = subview.superview?.superview, superview.isKind(of: UITableView.self) {
                 result.append(contentsOf: subview.subviews)
             } else {
                 result.append(subview)

--- a/SkeletonViewCore/Sources/Internal/UIKitExtensions/UIView+Extensions.swift
+++ b/SkeletonViewCore/Sources/Internal/UIKitExtensions/UIView+Extensions.swift
@@ -99,7 +99,7 @@ extension UIView {
     }
     
     var nonContentSizeLayoutConstraints: [NSLayoutConstraint] {
-        constraints.filter({ "\(type(of: $0))" != "NSContentSizeLayoutConstraint" })
+        constraints.filter({ type(of: $0) == NSLayoutConstraint.self })
     }
     
     /// Animations


### PR DESCRIPTION
### Summary

Delete some Apple private API, change  'NSContentSizeLayoutConstraint' & 'UITableViewWrapperView' usage.

### Requirements (place an `x` in each of the `[ ]`)
* [ x ] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [ x ] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
