### PR TITLE
Add PrivacyInfo manifest file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
     targets: [
         .target(
             name: "SkeletonView",
-            path: "SkeletonViewCore/Sources"
+            path: "SkeletonViewCore/Sources",
+            resources: [.copy("Supporting Files/PrivacyInfo.xcprivacy")],
         ),
         .testTarget(
             name: "SkeletonViewTests",

--- a/SkeletonView.xcodeproj/project.pbxproj
+++ b/SkeletonView.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -153,6 +153,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0AEC95C32AF537B600CD241A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		F5225F29278C2BCE0061A9B0 /* SkeletonTextNumberOfLines.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonTextNumberOfLines.swift; sourceTree = "<group>"; };
 		F53D731726D399E100249D46 /* SkeletonTreeNode+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SkeletonTreeNode+Extensions.swift"; sourceTree = "<group>"; };
 		F53D731A26D3A35100249D46 /* SkeletonExtended.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonExtended.swift; sourceTree = "<group>"; };
@@ -349,6 +350,7 @@
 			isa = PBXGroup;
 			children = (
 				F556F56226CD1D8500A80B83 /* Info.plist */,
+				0AEC95C32AF537B600CD241A /* PrivacyInfo.xcprivacy */,
 			);
 			path = "Supporting Files";
 			sourceTree = "<group>";

--- a/SkeletonViewCore/Sources/Supporting Files/PrivacyInfo.xcprivacy
+++ b/SkeletonViewCore/Sources/Supporting Files/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
### Summary

In this PR I added a PrivacyInfo manifest file which will be required starting Spring 2024 for all iOS application submitting to AppStore Connect.
SkeletonView uses UserDefaults which is one of the APIs required to be listed in a Privacy manifest file with the reason why it is being used.

Associated issue: https://github.com/Juanpe/SkeletonView/issues/551

<img width="784" alt="Screenshot 2023-11-03 at 10 27 14 AM" src="https://github.com/Juanpe/SkeletonView/assets/12569942/165d74ef-8883-4d4c-bf2e-6926ac9d87be">

The file requires all four fields to be included:
- SDK does not use tracking;
- Tracking domains array is empty. It can be empty as long as tracking is false;
- SDK does not collect any data. NSPrivacyCollectedDataTypes is empty;
- SDK uses UserDefaults, Reason: ["CA92.1 - Access info from same app, per documentation"](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401)

### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
