### PR TITLE
Fix syntax error in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .target(
             name: "SkeletonView",
             path: "SkeletonViewCore/Sources",
-            resources: [.copy("Supporting Files/PrivacyInfo.xcprivacy")],
+            resources: [.copy("Supporting Files/PrivacyInfo.xcprivacy")]
         ),
         .testTarget(
             name: "SkeletonViewTests",


### PR DESCRIPTION

### Summary

Fixes syntax error regarding an invalid trailing comma, which is preventing SkeletonView from being added as a dependency in client projects.

Relates to #553 

### Requirements (place an `x` in each of the `[ ]`)
* [ x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x ] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
