### PR TITLE
build: add PrivacyInfo.xcprivacy into podspec

### DIFF
--- a/SkeletonView.podspec
+++ b/SkeletonView.podspec
@@ -15,4 +15,5 @@ Pod::Spec.new do |s|
   s.swift_version = "5.0"
   s.source       = { :git => "https://github.com/Juanpe/SkeletonView.git", :tag => s.version.to_s }
   s.source_files  = "SkeletonViewCore/Sources/**/*.{swift,h}"
+  s.resource_bundles = {"SkeletonView" => ["SkeletonViewCore/Sources/Supporting Files/PrivacyInfo.xcprivacy"]}
 end


### PR DESCRIPTION
### Summary

The PrivacyInfo.xcprivacy file was not added into podspec

### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
