### PR TITLE
Adds iOS 12 Animation Class availability handling

### DIFF
--- a/SkeletonView.podspec
+++ b/SkeletonView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SkeletonView"
-  s.version      = "1.31.0"
+  s.version      = "1.32.0"
   s.summary      = "An elegant way to show users that something is happening and also prepare them to which contents he is waiting"
   s.description  = <<-DESC
   Today almost all apps have async processes, as API requests, long runing processes, etc. And while the processes are working, usually developers place a loading view to show users that something is going on.

--- a/SkeletonViewCore/Sources/API/AnimationBuilder/SkeletonAnimationBuilder.swift
+++ b/SkeletonViewCore/Sources/API/AnimationBuilder/SkeletonAnimationBuilder.swift
@@ -27,7 +27,11 @@ public class SkeletonAnimationBuilder {
             let animGroup = CAAnimationGroup()
             animGroup.animations = [startPointAnim, endPointAnim]
             animGroup.duration = duration
-            animGroup.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeIn)
+            if #available(iOS 12.0, *) {
+                animGroup.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeIn)
+            } else {
+                animGroup.timingFunction = CAMediaTimingFunction(controlPoints: 0.42, 0.0, 1.0, 1.0)
+            }
             animGroup.repeatCount = .infinity
             animGroup.autoreverses = autoreverses
             animGroup.isRemovedOnCompletion = false

--- a/SkeletonViewCore/Sources/API/UIKitExtensions/CALayer+Animations.swift
+++ b/SkeletonViewCore/Sources/API/UIKitExtensions/CALayer+Animations.swift
@@ -22,7 +22,11 @@ public extension CALayer {
         // swiftlint:disable:next force_unwrapping
         pulseAnimation.toValue = UIColor(cgColor: backgroundColor!).complementaryColor.cgColor
         pulseAnimation.duration = 1
-        pulseAnimation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
+        if #available(iOS 12.0, *) {
+            pulseAnimation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
+        } else {
+            pulseAnimation.timingFunction = CAMediaTimingFunction(controlPoints: 0.42, 0.0, 0.58, 1.0)
+        }
         pulseAnimation.autoreverses = true
         pulseAnimation.repeatCount = .infinity
         pulseAnimation.isRemovedOnCompletion = false

--- a/SkeletonViewCore/Sources/Internal/UIKitExtensions/CALayer+Extensions.swift
+++ b/SkeletonViewCore/Sources/Internal/UIKitExtensions/CALayer+Extensions.swift
@@ -76,7 +76,13 @@ extension CALayer {
         animation.fromValue = from
         animation.toValue = to
         animation.duration = duration
-        animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
+        
+        if #available(iOS 12.0, *) {
+            animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
+        } else {
+            animation.timingFunction = CAMediaTimingFunction(controlPoints: 0.42, 0.0, 0.58, 1.0)
+        }
+
         DispatchQueue.main.async { CATransaction.setCompletionBlock(completion) }
         add(animation, forKey: "setOpacityAnimation")
         DispatchQueue.main.async { CATransaction.commit() }


### PR DESCRIPTION
### Summary

From Xcode 16 beta 1 an error appears that the CAMediaTimingFunctionName animation is not available for versions below iOS 12, so a treatment was added for it to make it work with iOS 12

https://developer.apple.com/documentation/quartzcore/camediatimingfunctionname

issue: https://github.com/Juanpe/SkeletonView/issues/572

for versions below, animation was done using controlPoints
### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
