### PR TITLE
Update links

### DIFF
--- a/Translations/README_fr.md
+++ b/Translations/README_fr.md
@@ -95,7 +95,7 @@ Modifiez votre "Cartfile" et spécifiez la dépendance:
 github "Juanpe/SkeletonView"
 ```
 
-#### Utilisation du [gestionnaire de paquets Swift](https://github.com/apple/swift-package-manager)
+#### Utilisation du [gestionnaire de paquets Swift](https://swift.org/package-manager/)
 
 Une fois que vous avez configuré votre paquet Swift, ajouter `SkeletonView` comme dépendance est aussi facile que de l'ajouter à la valeur des `dépendances` de votre `Package.swift`.
 

--- a/Translations/README_ko.md
+++ b/Translations/README_ko.md
@@ -87,7 +87,7 @@ pod "SkeletonView"
 github "Juanpe/SkeletonView"
 ```
 
-#### [Swift Package Manager](https://github.com/apple/swift-package-manager)로 사용하기
+#### [Swift Package Manager](https://swift.org/package-manager/)로 사용하기
 
 
 당신의 프로젝트에 Swift package를 설정한다면, `SkeletonView` 를 `Package.swift` 파일에 있는 `dependencies`에 추가하시면 됩니다.


### PR DESCRIPTION
### Summary

Currently, the link change from **https://github.com/apple/swift-package-manager** to **https://github.com/swiftlang/swift-package-manager** , and the link in **"Translations/README_fr.md"** and **"Translations/README_ko.md"** are difference with **"README.md"** . I would like to sync the Swift Package Manager link with **"README.md"** .

### Requirements (place an `x` in each of the `[ ]`)
* [x] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
