### PR TITLE
Remove layout subviews to fix infinite loop crash: #495

### DIFF
--- a/SkeletonViewCore/Sources/Internal/UIKitExtensions/UIView+Swizzling.swift
+++ b/SkeletonViewCore/Sources/Internal/UIKitExtensions/UIView+Swizzling.swift
@@ -17,7 +17,6 @@ extension UIView {
 
     @objc func skeletonLayoutSubviews() {
         guard Thread.isMainThread else { return }
-        skeletonLayoutSubviews()
         guard sk.isSkeletonActive else { return }
         layoutSkeletonIfNeeded()
     }


### PR DESCRIPTION
### Summary
Fix infinite loop crash - issue https://github.com/Juanpe/SkeletonView/issues/495
Change is based on the discussions and forks mentioned in above thread
